### PR TITLE
Add glossary

### DIFF
--- a/docs/source/branch.rst
+++ b/docs/source/branch.rst
@@ -74,6 +74,13 @@ but simulation run time scales directly with the size of the population you're s
 you can run multiple simulations with different :term:`random seeds<Random Seed>` and aggregate your results across
 those simulations. This second approach takes advantage of parallel computing to keep run times under control.
 
+.. note::
+   
+    Random seeds are a convenient way to scale up a simulation's population in parallel. For example, running a
+    simulation with one million simulants and a single random seed is equivalent to running the same simulation with
+    ten thousand people and 100 random seeds. Because simulations specified with different seeds will be run
+    in parallel, the latter run strategy is often preferable.   
+
 To run our simulation for multiple random seeds, we use the ``random_seed_count`` key in a
 :term:`branch configuration<Branch Configuration>`. This key specifies an integer that represents the number of
 different random seeds to use, each generated randomly and run in a separate simulation.
@@ -163,22 +170,32 @@ Thus, you can expect four separate simulations to be run, one for each variation
 
 Interaction with Uncertainty
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-As touched upon in the section on :ref:`combining draws and seeds<Combining Draws and Seeds>`, when multiple
-:term:`branch configurations<Branch Configuration>` would result in multiple simulations the result is a simulation for
-every combination. Let's add draws to our previous branches file and figure out how many simulations it will result in.
+
+As touched upon in the section on :ref:`combining draws and seeds<Combining Draws and Seeds>`, each of the top
+level keys in a :term:`branch configuration<Branch Configuration>` can be independently produce a set of simulations
+to be run.  To find the total set of simulations to be run from a branch configuration file, we need to count
+the Cartesian product of the top level keys.  We'll use a slight alteration of our intervention configuration
+as an example.
+
 
 .. code-block:: yaml
     :caption: egg_intervention_with_parameter_uncertainty_branches.yaml
 
     input_draw_count: 100
+    random_seed_count: 4
 
     branches:
             - egg_intervention:
                     recruitment:
                         proportion: [0.0, 0.4, 0.8, 1.0]
 
-This branch configuration will produce 400 simulations. For each of the 100 :term:`input draws<Input Draw>` a
-simulation will be run with the egg intervention recruitment set to each of the four options in turn.
+This branch configuration will produce 400 simulations. First we consider the space of 
+:term:`configuration parameters<Configuration Parameter>` the simulation will be run for: one scenario for 
+each of the four recruitment proportions.  For each scenario, we will run a simulation for each combination
+of :term:`input draw<Input Draw>` and :term:`random seed<Random Seed>` specified byt the ``input_draw_count`` 
+and ``random_seed_count`` keys.  So we'll have:
+``(Number of input draws) * (Number of random seeds) * (Number of scenarios) = 100 * 4 * 4 = 1600`` 
+simulations to run from this branch configuration.
 
 Multi-parameter Variation
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/source/branch.rst
+++ b/docs/source/branch.rst
@@ -47,7 +47,7 @@ This key refers to an integer that represents the number of different input draw
     input_draw_count: 10
 
 When we use this branch configuration along with the original :term:`model specification<Model Specification>`,
-we'll launch 10 simulations in parallel, each using a different set of input paramemters represented by the
+we'll launch 10 simulations in parallel, each using a different set of input parameters represented by the
 draw number.
 
 .. code-block:: sh
@@ -119,7 +119,7 @@ Configuration Variations
 
 A major function of :term:`branch configurations<Branch Configuration>` is to enable easy manipulation of
 the :term:`configuration parameters<Configuration Parameter>` of a :term:`model specification<Model Specification>`.
-These parameters generally govern interesting features of an intervention, such as it's target coverage or efficacy.
+These parameters generally govern interesting features of an intervention, such as its target coverage or efficacy.
 
 Within a branch configuration, you can specify several variations of these parameters to generate different
 scenarios or examine the sensitivity of a model to changes in a specific parameter. In the following sections we
@@ -203,7 +203,7 @@ branches file like so:
 
 This will result in scenarios encompassing every combination of recruitment proportion and starting age. Additionally,
 it will result in 100 simulations for each one of the scenarios, one for each of the :term:`input draws<Input Draw>`.
-This means the total number of simulations is given by ``(Number of input draws) * (Number of recruitment proportions
+This means the total number of simulations is given by ``(Number of input draws) * (Number of recruitment proportions)
 * (Number of starting ages)`` giving a total of 1600 simulations.
 
 Complex Configurations

--- a/docs/source/branch.rst
+++ b/docs/source/branch.rst
@@ -8,125 +8,167 @@ The Branches File
     :backlinks: none
 
 When investigating a research question with the Vivarium framework, it usually becomes necessary to vary aspects of a
-model configuration in order to evaluate the uncertainty of model outputs or to explore different scenarios based on
-model parameters. Without any extra tooling this would require manually manipulating the model specification file and
-re-running for each desired change which would quickly get out of hand. The branches file helps us do this in a
-convenient way. This section will detail the common ways simulations are varied and the different aspects of a branches
-file that help us do this.
+:term:`model specification<Model Specification>` in order to evaluate the uncertainty of model outputs or to explore
+different scenarios based on model parameters. Without any extra tooling this would require manually manipulating
+the model specification file and re-running for each desired change, which would quickly get out of hand.
+The :term:`branch configuration<Branch Configuration>` helps us do this in a convenient way. This section will detail
+the common ways simulations are varied and the different aspects of a branch configuration that help us do this.
 
 Uncertainty
 -----------
 
 Generating uncertainty for results is a core tenant of IHME and this is no different for simulation science. We are
-primarily concerned with uncertainty from two sources in our models -- uncertainty surrounding the data that goes in to
-a model and uncertainty due to stochasticity. The branches file can help us explore these uncertainties easily by
-allowing us to vary the input draws from the Global Burden of Disease (GBD) used as well as the random seeds used by the
-simulation.
+primarily concerned with two kinds of uncertainy in our model -- :term:`parameter uncertainy<Parameter Uncertainty>`
+and :term:`stochastic uncertainty<Stochastic Uncertainty>`. The branch configuration can help us explore both sources
+of uncertainty by varying both the :term:`input draw<Input Draw>` of the parameter data and the
+:term:`seed<Random Seed>` of the simulation's random number generator.
 
-Data Uncertainty
-^^^^^^^^^^^^^^^^
-Our simulations primarily rely on GBD results which are produced in draws to estimate uncertainty. In order to reflect
-the GBD's uncertainty surrounding their results in our simulations, we generally run simulations with a variety of
-output draws.
+Parameter Uncertainty
+^^^^^^^^^^^^^^^^^^^^^
+Our simulations primarily rely on results from the Global Burden of Disease (GBD). GBD results are produced with
+:term:`uncertainy<Parameter Uncertainty>` represented as :term:`draws<Input Draw>`. Once we have a model we trust,
+we typically want to capture our uncertainty in the input data by running the simulation model for several different
+input draws.
 
 .. note::
+
     A draw is a statistical term related to bootstrapping that has a specific meaning in the context of the GBD. The
-    implementation details vary, but the purpose is for
+    implementation details vary, but the purpose is for some quantity or measure of interest, a draw is a member of
+    a full set of results such that, when taken together, the set of draws describes at least some of the uncertainty
+    surrounding the quantity as a result of the modeling process, data uncertainty, etc. Generally, GBD results are
+    produced in sets of 1000 draws.
 
-    some quantity or measure of interest, a draw is a member of a full set of results such that, when taken
-    together, the set of draws describes at least some of the uncertainty surrounding the quantity as a result of the
-    modeling process, data uncertainty, etc. Generally, GBD results are produced in sets of 1000 draws.
-
-To do this, we can use the ``input_draw_count`` key in a branches file. This key specifies an integer that represents
-the number of different simulations that will be run in parallel, each with a different draw of GBD results drawn
-uniformly from the number available, which is generally 1,000. Below is a very simple branches file containing only a
-mapping that dictates the number of draws to run.
+To do this, we can use the ``input_draw_count`` key in a :term:`branch configuration<Branch Configuration>`.
+This key refers to an integer that represents the number of different input draws to generate simulations from.
 
 .. code-block:: yaml
+    :caption: parameter_uncertainty_branches.yaml
 
     input_draw_count: 10
 
-Stochastic Uncertainty
-^^^^^^^^^^^^^^^^^^^^^^
-Vivarium simulations are probabilistic in nature. They tend to contain distributions that describe quantities rather
-than singular values. Because of this, our models are subject to stochastic uncertainty. To attempt to capture some of
-this uncertainty we can run the simulation with different random seeds which will result in different numbers drawn from
-the underlying pseudo-random number generator, and thus different output results. This can be specified in the branches
-file with the ``random_seed_count`` key. This key specifies an integer that represents the number of different random
-seeds to use, each generated randomly and run in a separate simulation.
+When we use this branch configuration along with the original :term:`model specification<Model Specification>`,
+we'll launch 10 simulations in parallel, each using a different set of input paramemters represented by the
+draw number.
+
+.. code-block:: sh
+
+  psimulate run /path/to/model_specification.yaml /path/to/parameter_uncertainty_branches.yaml
+
 
 .. note::
-    Random seeds are a convenient way to scale up a simulation's population in parallel. For example, running a
-    simulation with one million simulants and a single random seed is equivalent to running the same simulation with
-    ten thousand people and 100 random seeds. However, because simulations specified with different seeds will be run
-    in parallel (link psimulate), this is often preferable.
 
-An example of specifying ``random_seed_count`` is below.
+  ``psimulate`` randomly selects the input draws it uses from the range [0, 999].  The selection
+  happens without replacement, so specifying an ``input_draw_count`` of 10 guarantees you
+  10 unique input draws.
+
+
+Stochastic Uncertainty
+^^^^^^^^^^^^^^^^^^^^^^
+Vivarium simulations are probabilistic in nature. They use Monte Carlo sampling techniques to make decisions about
+who gets sick, who goes to the hospital, who dies, etc. This usage of randomness means our models have to
+consider the impact of :term:`stochastic uncertainty<Stochastic Uncertainty>` on its outputs.
+
+There are two ways to handle stochastic uncertainty. The first is to increase the size of the population you're
+simulating. This will wash out outlier cases that might heavily skew your results. This works fine up to a point,
+but simulation run time scales directly with the size of the population you're simulating.  Alternatively,
+you can run multiple simulations with different :term:`random seeds<Random Seed>` and aggregate your results across
+those simulations. This second approach takes advantage of parallel computing to keep run times under control.
+
+To run our simulation for multiple random seeds, we use the ``random_seed_count`` key in a
+:term:`branch configuration<Branch Configuration>`. This key specifies an integer that represents the number of
+different random seeds to use, each generated randomly and run in a separate simulation.
 
 .. code-block:: yaml
+    :caption: stochastic_uncertainty_branches.yaml
 
     random_seed_count: 100
 
+When we use this branch configuration along with the original :term:`model specification<Model Specification>`,
+we'll launch 100 simulations in parallel, each using a different random seed.
+
+.. code-block:: sh
+
+  psimulate run /path/to/model_specification.yaml /path/to/stochastic_uncertainty_branches.yaml
+
+
 Combining Draws and Seeds
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-Since specifying either draws or seeds will result in multiple simulations being run, it is important to understand how
-simulation configurations are determined when both are specified. The specification of multiple branch configurations
-that would result in more than one simulation will lead to simulations for the cartesian product of the
-configuration sets. An example may make this clearer, so consider the following model specification.
+Since specifying either :term:`input draws<Input Draw>` or :term:`random seeds<Random Seed>` will result in multiple
+simulations being run, it is important to understand how :term:`branch configurations<Branch Configuration>` are
+parsed into simulations when both keys are specified. Specifying both an ``input_draw_count`` and a
+``random_seed_count`` will result in a set of input draws and a set of random seeds being independently
+generated. Simulations will then be run for each unique combination of input draw and random seed (the
+Cartesian product of the two sets).
+
+An example may make this clearer, so consider the following model specification.
 
 .. code-block:: yaml
+    :caption: combined_uncertainty_branches.yaml
 
     input_draw_count: 100
     random_seed_count: 10
 
 It combines the two configuration keys we just learned about. Taken separately, the ``input_draw_count`` mapping would
-lead to 100 simulations on 100 random draws of input data while the ``random_seed_count`` mapping would lead to ten
-simulations on ten randomly generated random seeds. With both specified, the result is one thousand total simulations,
-one for each member of the cartesian product of those sets. That is, ten simulations with the ten random seeds for each
-of the 100 GBD draws.
+lead to 100 simulations on 100 draws of input data while the ``random_seed_count`` mapping would lead to ten
+simulations on with identical input data but a different seed for the random number generation. With both specified,
+the result is 1,000 total simulations, one for each member of the Cartesian product of those sets. That is,
+we would run ten simulations with the ten random seeds for each of the 100 input data draws.
 
-Parameter Variations
---------------------
-A major function of branches files is to enable easy manipulation of the configuration parameters of a model
-specification to generate different scenarios or examine the sensitivity of a model to changes in a specific parameter.
-In the following sections we will describe a number of ways you can construct different scenarios and the effect on
-the number of simulations these will have.
+Configuration Variations
+------------------------
+
+A major function of :term:`branch configurations<Branch Configuration>` is to enable easy manipulation of
+the :term:`configuration parameters<Configuration Parameter>` of a :term:`model specification<Model Specification>`.
+These parameters generally govern interesting features of an intervention, such as it's target coverage or efficacy.
+
+Within a branch configuration, you can specify several variations of these parameters to generate different
+scenarios or examine the sensitivity of a model to changes in a specific parameter. In the following sections we
+will describe a number of ways you can construct different scenarios and explain how to compute the number of
+simulations that will be run for a particular branch configuration.
 
 .. note::
-    The following examples that alter configuration parameters all lie under a ``branches`` key.
+
+    The following examples that alter configuration parameters all lie under a ``branches`` key. This is the only
+    other top level key (besides ``input_draw_count`` and ``random_seed_count``) that ``psimulate`` understands
+    how to parse.
 
 Single Parameter Variation
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
-In order to illustrate the variation of a single parameter, let's assume you have defined a model specification file
-that includes a dietary intervention of egg supplementation and that this intervention is parameterized by the
-proportion of the population that is recruited into the intervention program. We may want to run simulations on several
-different proportions including full recruitment and no recruitment, which would function as a baseline. We can easily
-do this with the following branches file.
+
+In order to illustrate the variation of a single :term:`parameter<Configuration Parameter>`, let's assume
+you have defined a :term:`model specification<Model Specification>` that includes a dietary intervention of
+egg supplementation and that this intervention is parameterized by the proportion of the population that is recruited
+into the intervention program. We may want to run simulations on several different proportions including full
+recruitment and no recruitment, which would function as a baseline. We can easily do this with the following
+branches file.
 
 .. code-block:: yaml
+    :caption: egg_intervention_branches.yaml
 
     branches:
             - egg_intervention:
                     recruitment:
                         proportion: [0.0, 0.4, 0.8, 1.0]
 
-The ``branches`` block specifies changes to values found in the model specification YAML, exactly matching the blocks
-from that specification underneath.  Here, the YAML list [0.0, 0.4, 0.8, 1.0] dictates specific recruitment proportions
-to be simulated. Thus, you can expect four separate simulations to be run, one for each.
+The ``branches`` block specifies changes to values found in the configuration block of the original model specification
+YAML. The block found in the branches file must exactly match the block from the original model specification.
+Here, the YAML list [0.0, 0.4, 0.8, 1.0] dictates specific recruitment proportions to be simulated.
+Thus, you can expect four separate simulations to be run, one for each variation.
 
 .. warning::
+
     Varying the time step, start or end time, or the population size of a simulation will make profiling very difficult
     and runs the risk of breaking our output writing tools.
 
 
 Interaction with Uncertainty
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-As touched upon in the section on :ref:`combining draws and seeds<Combining Draws and Seeds>`, when multiple branch
-configurations would result in multiple simulations, the result is a simulation for every combination, or the cartesian
-product, of the parameters. Let's add draws to our previous branches file and figure out how many simulations it will
-result in.
+As touched upon in the section on :ref:`combining draws and seeds<Combining Draws and Seeds>`, when multiple
+:term:`branch configurations<Branch Configuration>` would result in multiple simulations the result is a simulation for
+every combination. Let's add draws to our previous branches file and figure out how many simulations it will result in.
 
 .. code-block:: yaml
+    :caption: egg_intervention_with_parameter_uncertainty_branches.yaml
 
     input_draw_count: 100
 
@@ -135,16 +177,21 @@ result in.
                     recruitment:
                         proportion: [0.0, 0.4, 0.8, 1.0]
 
-This branches file will result in 400 simulations, a set of 100 different draws for each recruitment proportion.
+This branch configuration will produce 400 simulations. For each of the 100 :term:`input draws<Input Draw>` a
+simulation will be run with the egg intervention recruitment set to each of the four options in turn.
 
-Dual Parameter Variation
-^^^^^^^^^^^^^^^^^^^^^^^^
-Branches files really shine when you want to vary a lot of aspects of your model. Let's add another parameter to create
-scenarios along a new dimension. Say, for instance, we were also interested in the implementing the egg intervention
-by recruiting people only once they pass a certain age threshold. Provided components were available that can implement
-this, we could add a variety of starting ages to our branches file like so:
+Multi-parameter Variation
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+:term:`Branch configurations<Branch Configuration>` really shine when you want to vary a lot of aspects of your model.
+
+Let's add another :term:`parameter<Configuration Parameter>` to create scenarios along a new dimension. Say, for instance,
+we were also interested in the implementing the egg intervention by recruiting people only once they pass a certain age
+threshold. Provided components were available that can implement this, we could add a variety of starting ages to our
+branches file like so:
 
 .. code-block:: yaml
+    :caption: egg_intervention_with_ages_branches.yaml
 
     input_draw_count: 100
 
@@ -154,65 +201,42 @@ this, we could add a variety of starting ages to our branches file like so:
                         proportion: [0.0, 0.4, 0.8, 1.0]
                         age_start: [10.0, 25.0, 45.0, 65.0]
 
-This will result in scenarios encompassing every combination of recruitment proportion and starting age. Specifically,
-it will result in 100 separate simulations per combination, one for each randomly sampled draw. This means the total
-number of simulations is given by draws * proportions * starting age, or 1,600 altogether.
-
-.. note:: The top-level keys for controlling seeds and draws are the same across branches.
+This will result in scenarios encompassing every combination of recruitment proportion and starting age. Additionally,
+it will result in 100 simulations for each one of the scenarios, one for each of the :term:`input draws<Input Draw>`.
+This means the total number of simulations is given by ``(Number of input draws) * (Number of recruitment proportions
+* (Number of starting ages)`` giving a total of 1600 simulations.
 
 Complex Configurations
 ^^^^^^^^^^^^^^^^^^^^^^
-Let's look at a final example with a bit more going on. This branches file alters a model that simulates a Shigellosis
-vaccine intervention parameterized on dose administration ages and dose protection effects.
+
+Let's look at a final example with a bit more going on. Note that in our last example
+:term:`branch configuration<Branch Configuration>` we did significantly more work than we needed to. When our recruitment
+proportion is ``0``, it doesn't matter what age we start recruiting people at.  This caused us to run 300 more simulations
+than we needed to.  How do we write a better branch configuration?
 
 .. code-block:: yaml
+    :caption: better_egg_intervention_with_ages_branches.yaml
 
-    input_draw_count: 500
+    input_draw_count: 100
     random_seed_count: 4
 
     branches:
-            - shigellosis_vaccine:
-                    dose_age_range:
-                            first:
-                                    start: 270
-                                    end: 300
-                            second:
-                                    start: 360
-                                    end: 390
-                            booster:
-                                    start: 450
-                                    end: 480
-                            catchup:
-                                    start: 450
-                                    end: 480
-                    protection:
-                            dose_protection:
-                                    first: 0.0
-                                    second: 0.0
-                                    booster: 0.0
-                                    catchup: 0.0
-            - shigellosis_vaccine:
-                    dose_age_range :
-                            first :
-                                    start: 270
-                                    end: 300
-                            second :
-                                    start: 360
-                                    end: 390
-                            booster :
-                                    start: 450
-                                    end: 480
-                            catchup :
-                                    start: 450
-                                    end: 480
-                    protection:
-                            dose_protection:
-                                    first: 0.7
-                                    second: 1.0
-                                    booster: 0.0
-                                    catchup: 0.0
+            # Baseline scenario
+            - egg_intervention:
+                  recruitment:
+                      proportion: 0.0
+            # Intervention variations
+            - egg_intervention:
+                  recruitment:
+                      proportion: [0.4, 0.8, 1.0]
+                      age_start: [10.0, 25.0, 45.0, 65.0]
 
-The :ref:`YAML List<Lists>` underneath the ``branches`` key denotes two different simulation scenario each with a set of
-parameters. Because all of the children of those list entries are singular values, only one simulation is produced for
-each. Since we have additionally specified counts for draws and random seeds, we will run a simulation for each of these
-scenarios, for each combination of random seed and draw. This will result in 4,000 total simulations.
+The :ref:`YAML List<Lists>` underneath the ``branches`` key denotes two different simulation scenario branches
+each with a set of :term:`configuration parameters<Configuration Parameter>`. We resolve each one of the list
+items under the ``branches`` key separately.  The first block resolves to a single baseline scenario.
+The second block resolves to three different recruitment proportions for four different ages, which produces
+a total of 12 intervention scenarios.  Thus the entire ``branches`` block resolves to 13 different sets of
+configuration parameters.
+
+Following the same logic as in the previous section, we compute the total number of simulations to be run as
+``(Number of input draws) * (Number of random seeds) * (Number of scenarios) = 100 * 4 * 13 = 5200``.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -24,7 +24,7 @@
     using random numbers to sample from distributions. Our simulations
     control stochastic uncertainty with :term:`random seeds<Random Seed>`.
     Stochastic uncertainty in simulations is deeply related to sampling
-    uncertanty in a study. By holding the input parameters constant and
+    uncertainty in a study. By holding the input parameters constant and
     varying the random seed, we can produce many realizations (or samples)
     of the same underlying population and use that to minimize the
     stochastic uncertainty.

--- a/docs/source/glossary.rst
+++ b/docs/source/glossary.rst
@@ -1,0 +1,52 @@
+.. glossary::
+
+  Model Specification
+    A yaml file that details all components and configuration necessary to run
+    a particular model.
+
+  Branch Configuration
+    A yaml file that lists the count of input data draws and random seeds as
+    well as a set of simulation configuration options. When coupled with a
+    model specification, this file defines a set of different simulation
+    scenarios that can be run in parallel with the ``psimulate`` command
+    line utility.
+
+  Parameter Uncertainty
+    Parameter uncertainty is uncertainty due to the input data. The Global
+    Burden of Disease represents uncertainy distributions around the parameters
+    it produces with :term:`draws<Input Draw>`. By running a simulation with
+    several different draws of the input data, we can propagate the parameter
+    uncertainty through our model and to our outputs.
+
+  Stochastic Uncertainty
+    Stochastic uncertainty is uncertainty due to the inherent variability in
+    the model. This variability is represented in a variety of places by
+    using random numbers to sample from distributions. Our simulations
+    control stochastic uncertainty with :term:`random seeds<Random Seed>`.
+    Stochastic uncertainty in simulations is deeply related to sampling
+    uncertanty in a study. By holding the input parameters constant and
+    varying the random seed, we can produce many realizations (or samples)
+    of the same underlying population and use that to minimize the
+    stochastic uncertainty.
+
+  Input Draw
+    A way of representing uncertainty in the input parameters. Rather than
+    having an explicit distribution, each input draw of a parameter is 
+    a sample from the underlying distribution of that parameter in a population.
+    Taken collectively, all the input draws form a numeric representation of
+    the original parameter distribution.
+
+  Random Seed
+    A number used to seed the simulation's random number generator. Two
+    simulations run with the same random seed will produce the same random
+    numbers for each decision made in the simulation on each time step for
+    each person.
+
+  Configuration Parameter
+    A parameter of a given model specified in the ``configuration`` block
+    of the :term:`model specification<Model Specification>`. Typically
+    determined early on in the model development process, these parameters
+    determine what scenarios can be run with a given model.  Common
+    configuration parameters include the target coverage of an intervention,
+    what subset of a population the intervention targets, and how effective
+    an intervention is.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -16,3 +16,4 @@ simulations at scale on a Univa Grid Engine cluster easy.
    distributed_runner
    yaml_basics
    branch
+   glossary


### PR DESCRIPTION
- Added a glossary
- Put in glossary references in the branches text
- Some general edits for clarity
- Follow through with the initial example in the final branches section.