### PR TITLE
cast results to dtypes from pre-np new results

### DIFF
--- a/src/vivarium_cluster_tools/runner.py
+++ b/src/vivarium_cluster_tools/runner.py
@@ -237,19 +237,27 @@ def build_job_list(ctx):
     return jobs
 
 
+def np_concat_preserve_types(df_list):
+    dtypes = df_list[0].dtypes
+    splits = []
+    for dtype in dtypes:
+        slices = [df.select_dtype(dtype).values for df in df_list]
+        splits.append(np.concatenate(slices))
+    out = np.concatenate(splits, axis=1)
+    return out
+
+
 def concat_results(old_results, new_results):
     # Skips all the pandas index checking because columns are in the same order.
     start = time()
     if not old_results.empty:
         old_results = old_results.reset_index(drop=True)
-        results = pd.DataFrame(data=np.concatenate([d.values for d in new_results] + [old_results.values]),
+        results = pd.DataFrame(data=np_concat_preserve_types(new_results + [old_results]),
                                columns=old_results.columns)
     else:
         columns = new_results[0].columns
-        results = pd.DataFrame(data=np.concatenate([d.reset_index(drop=True).values for d in new_results]),
+        results = pd.DataFrame(data=np_concat_preserve_types([d.reset_index(drop=True) for d in new_results]),
                                columns=columns)
-    dtypes = new_results[0].dtypes
-    results = results.astype(dtypes)
     results = results.set_index(['input_draw', 'random_seed'], drop=False)
     results.index.names = ['input_draw_number', 'random_seed']
     end = time()

--- a/src/vivarium_cluster_tools/runner.py
+++ b/src/vivarium_cluster_tools/runner.py
@@ -248,6 +248,8 @@ def concat_results(old_results, new_results):
         columns = new_results[0].columns
         results = pd.DataFrame(data=np.concatenate([d.reset_index(drop=True).values for d in new_results]),
                                columns=columns)
+    dtypes = new_results[0].dtypes
+    results = results.astype(dtypes)
     results = results.set_index(['input_draw', 'random_seed'], drop=False)
     results.index.names = ['input_draw_number', 'random_seed']
     end = time()


### PR DESCRIPTION
This preserves type info by hanging on to the dtypes of the fresh results from a worker and using them to cast the results dataframe. Both asking for values from a dataframe and concatenating dataframes of differing types will clobber type info, so we have to do this every time.

For ~1500 columns it adds about a second of overhead per concat_results call