### PR TITLE
Bugfix/mismatched shapes concat

### DIFF
--- a/src/vivarium_cluster_tools/runner.py
+++ b/src/vivarium_cluster_tools/runner.py
@@ -239,7 +239,7 @@ def build_job_list(ctx):
 
 def concat_preserve_types(df_list):
     dtypes = df_list[0].dtypes
-    columns_by_dtype = [list(d[1].index) for d in dtypes.groupby(dtypes)]
+    columns_by_dtype = [list(dtype_group.index) for _, dtype_group in dtypes.groupby(dtypes)]
 
     splits = []
     for columns in columns_by_dtype:

--- a/src/vivarium_cluster_tools/runner.py
+++ b/src/vivarium_cluster_tools/runner.py
@@ -238,10 +238,10 @@ def build_job_list(ctx):
 
 
 def np_concat_preserve_types(df_list):
-    dtypes = df_list[0].dtypes
+    dtypes = df_list[0].dtypes.unique()
     splits = []
     for dtype in dtypes:
-        slices = [df.select_dtype(dtype).values for df in df_list]
+        slices = [df.select_dtypes(dtype).values for df in df_list]
         splits.append(np.concatenate(slices))
     out = np.concatenate(splits, axis=1)
     return out

--- a/src/vivarium_cluster_tools/runner.py
+++ b/src/vivarium_cluster_tools/runner.py
@@ -239,10 +239,10 @@ def build_job_list(ctx):
 
 def concat_preserve_types(df_list):
     dtypes = df_list[0].dtypes
-    dtypes = [list(d[1].index) for d in dtypes.groupby(dtypes)]
+    columns_by_dtype = [list(d[1].index) for d in dtypes.groupby(dtypes)]
 
     splits = []
-    for columns in dtypes:
+    for columns in columns_by_dtype:
         slices = [df.filter(columns) for df in df_list]
         splits.append(pd.DataFrame(data=np.concatenate(slices), columns=columns))
     return pd.concat(splits, axis=1)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,7 +1,7 @@
 import pytest
 import pandas as pd
 
-from vivarium_cluster_tools.runner import np_concat_preserve_types
+from vivarium_cluster_tools.runner import np_concat_preserve_types, concat_results
 
 
 @pytest.mark.parametrize('data_types', [[0, 1, 2],
@@ -26,7 +26,43 @@ def test_np_concat_preserve_types(data_types):
 
     expected_shape = (df.shape[0] + df2.shape[0], df.shape[1])
 
+    for c in df:
+        assert (result[c] == df[c].append(df2[c]).reset_index(drop=True)).all()
+
     assert result.shape == expected_shape
     assert (result.dtypes == expected_dtypes).all()
 
 
+@pytest.mark.parametrize('data_types', [[0, 1, 2],
+                                        [0, 0.0, 1, 2, 3],
+                                        [0.0, 1.0, 1.987987],
+                                        [0, 'a', 1, 'b', 1.2],
+                                        ['a', 'b', 'c', 'd']],
+                                        ids=['just ints',
+                                             'ints and floats',
+                                             'just floats',
+                                             'ints, floats, and strings',
+                                             'just strings'])
+def test_concat_results(data_types):
+    old = pd.DataFrame([data_types])
+    new = pd.DataFrame([[d*2 for d in data_types]])
+
+    old['input_draw'] = old['random_seed'] = 0.0
+    new['input_draw'] = new['random_seed'] = 1.0
+
+    old = old.set_index(['input_draw', 'random_seed'], drop=False)
+    new = new.set_index(['input_draw', 'random_seed'], drop=False)
+
+    combined = concat_results(old, [new])
+
+    expected_dtypes = old.dtypes
+    if (expected_dtypes == 'float64').any():
+        expected_dtypes.loc[expected_dtypes == 'int64'] = 'float64'  # np converts int64 to floats if any floats
+
+    expected_shape = (old.shape[0] + new.shape[0], old.shape[1])
+
+    for c in old:
+        assert (combined[c] == new[c].append(old[c])).all()
+
+    assert combined.shape == expected_shape
+    assert (combined.dtypes == expected_dtypes).all()

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -63,3 +63,8 @@ def test_concat_results(data_types):
 
     assert combined.shape == expected_shape
     assert combined.dtypes.sort_index().equals(expected_dtypes.sort_index())
+
+    # now no existing results
+    no_old_combined = concat_results(pd.DataFrame(), [new, old])
+
+    assert no_old_combined.equals(combined)

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,0 +1,32 @@
+import pytest
+import pandas as pd
+
+from vivarium_cluster_tools.runner import np_concat_preserve_types
+
+
+@pytest.mark.parametrize('data_types', [[0, 1, 2],
+                                        [0, 0.0, 1, 2, 3],
+                                        [0.0, 1.0, 1.987987],
+                                        [0, 'a', 1, 'b', 1.2],
+                                        ['a', 'b', 'c', 'd']],
+                                        ids=['just ints',
+                                             'ints and floats',
+                                             'just floats',
+                                             'ints, floats, and strings',
+                                             'just strings'])
+def test_np_concat_preserve_types(data_types):
+    df = pd.DataFrame([data_types])
+    df2 = pd.DataFrame([[d*2 for d in data_types]])
+
+    result = pd.DataFrame(np_concat_preserve_types([df, df2]))
+
+    expected_dtypes = df.dtypes
+    if (expected_dtypes == 'float64').any():
+        expected_dtypes.loc[expected_dtypes == 'int64'] = 'float64'  # np converts int64 to floats if any floats
+
+    expected_shape = (df.shape[0] + df2.shape[0], df.shape[1])
+
+    assert result.shape == expected_shape
+    assert (result.dtypes == expected_dtypes).all()
+
+


### PR DESCRIPTION
this finishes the concatenating stuff + fixes another small bug where it tried to write non-existent results if the no_batch flag was turned on. I tested it with a little toy sim (1 cause + 1 risk that runs for 1 year) with 8 random seed/draw combos. 