### PR TITLE
handle restarting with only draws/seeds

### DIFF
--- a/src/vivarium_cluster_tools/branches.py
+++ b/src/vivarium_cluster_tools/branches.py
@@ -137,7 +137,7 @@ def calculate_random_seeds(random_seed_count, existing_seeds=None):
         min_possible = 0
 
     low, high = min_possible, min_possible + 10*random_seed_count
-    return np.random.randint(low, high, size=random_seed_count).tolist()
+    return np.random.randint(low, high, size=random_seed_count).tolist() if random_seed_count else []
 
 
 def calculate_keyspace(branches):

--- a/src/vivarium_cluster_tools/runner.py
+++ b/src/vivarium_cluster_tools/runner.py
@@ -195,13 +195,14 @@ def build_job_list(ctx):
         if ctx.existing_outputs is not None:
             mask = ctx.existing_outputs.input_draw == int(input_draw)
             mask &= ctx.existing_outputs.random_seed == int(random_seed)
-            for k, v in collapse_nested_dict(branch_config):
-                if isinstance(v, float):
-                    # FIXME: The fast concat method will coerce floats to objects when writing
-                    # if there is one or more string columns.  Hack a coercion here to make restart work.
-                    mask &= np.isclose(ctx.existing_outputs[k].astype(float), v)
-                else:
-                    mask &= ctx.existing_outputs[k] == v
+            if branch_config:
+                for k, v in collapse_nested_dict(branch_config):
+                    if isinstance(v, float):
+                        # FIXME: The fast concat method will coerce floats to objects when writing
+                        # if there is one or more string columns.  Hack a coercion here to make restart work.
+                        mask &= np.isclose(ctx.existing_outputs[k].astype(float), v)
+                    else:
+                        mask &= ctx.existing_outputs[k] == v
             do_schedule = not np.any(mask)
 
         if do_schedule:

--- a/src/vivarium_cluster_tools/runner.py
+++ b/src/vivarium_cluster_tools/runner.py
@@ -198,9 +198,7 @@ def build_job_list(ctx):
             if branch_config:
                 for k, v in collapse_nested_dict(branch_config):
                     if isinstance(v, float):
-                        # FIXME: The fast concat method will coerce floats to objects when writing
-                        # if there is one or more string columns.  Hack a coercion here to make restart work.
-                        mask &= np.isclose(ctx.existing_outputs[k].astype(float), v)
+                        mask &= np.isclose(ctx.existing_outputs[k], v)
                     else:
                         mask &= ctx.existing_outputs[k] == v
             do_schedule = not np.any(mask)


### PR DESCRIPTION
hit these two little bugs around restarting/expanding testing the log rotation stuff I set up so this is just the bugs:

1. handle restarting/expanding with no branches (just draws/seeds so branch_config is None not a dict)
2. handle expanding with additional seeds but no draws 