### PR TITLE
Feature/log parsing

### DIFF
--- a/src/vivarium_cluster_tools/cli.py
+++ b/src/vivarium_cluster_tools/cli.py
@@ -1,6 +1,6 @@
 import click
 
-from vivarium_cluster_tools import runner, utilities, globals as vct_globals
+from vivarium_cluster_tools import runner, utilities, log_parser, globals as vct_globals
 
 
 shared_options = [
@@ -123,3 +123,18 @@ def expand(results_root, **options):
          expand={'num_draws': options['add_draws'],
                  'num_seeds': options['add_seeds']},
          no_batch=options['no_batch'])
+
+
+@psimulate.command()
+@click.argument('logs-directory', type=click.Path(exists=True, file_okay=False))
+@click.option('--result-directory', '-o', type=click.Path(exists=True, file_okay=False),
+              help='The directory into which to write the summary of the parsed logs. '
+                   'Defaults to given logs directory if not given.')
+@click.option('-v', 'verbose', count=True, help='Configure logging verbosity.')
+def parse_logs(logs_directory, result_directory, verbose):
+    """Parse the worker_logs from a previous ``psimulate run`` into a more
+    easily digestable summary form. """
+    utilities.configure_master_process_logging_to_terminal(verbose)
+    if not result_directory:
+        result_directory = logs_directory
+    log_parser.parse_log_directory(logs_directory, result_directory)

--- a/src/vivarium_cluster_tools/cli.py
+++ b/src/vivarium_cluster_tools/cli.py
@@ -133,7 +133,14 @@ def expand(results_root, **options):
 @click.option('-v', 'verbose', count=True, help='Configure logging verbosity.')
 def parse_logs(logs_directory, result_directory, verbose):
     """Parse the worker_logs from a previous ``psimulate run`` into a more
-    easily digestable summary form. """
+    easily digestable summary form.
+
+    Given a worker logs directory from a previous run, a summary hdf will be
+    created in the ``result_directory`` (which defaults to the given logs
+    directory unless otherwise specified) with two keys: 'worker_data', which
+    includes a summary line for each worker log in the directory and 'sim_data',
+    which includes a summary line for each simulation job run by a worker.
+    """
     utilities.configure_master_process_logging_to_terminal(verbose)
     if not result_directory:
         result_directory = logs_directory

--- a/src/vivarium_cluster_tools/log_parser.py
+++ b/src/vivarium_cluster_tools/log_parser.py
@@ -157,7 +157,7 @@ class WorkerLog:
 
 def parse_log_directory(input_directory: Union[Path, str], output_directory: Union[Path, str]):
     input_directory, output_directory = Path(input_directory), Path(output_directory)
-    log_files = [f for f in input_directory.iterdir()]
+    log_files = [f for f in input_directory.iterdir() if f.suffix == '.log']
 
     worker_data = []
     sim_data = []

--- a/src/vivarium_cluster_tools/log_parser.py
+++ b/src/vivarium_cluster_tools/log_parser.py
@@ -4,6 +4,7 @@ import json
 from loguru import logger
 from pathlib import Path
 import pandas as pd
+from typing import Union
 
 
 class LogType(Enum):
@@ -154,7 +155,8 @@ class WorkerLog:
         return worker, pd.concat(sims)
 
 
-def parse_log_directory(input_directory: Path, output_directory: Path):
+def parse_log_directory(input_directory: Union[Path, str], output_directory: Union[Path, str]):
+    input_directory, output_directory = Path(input_directory), Path(output_directory)
     log_files = [f for f in input_directory.iterdir()]
 
     worker_data = []

--- a/src/vivarium_cluster_tools/log_parser.py
+++ b/src/vivarium_cluster_tools/log_parser.py
@@ -1,0 +1,156 @@
+from enum import Enum
+import json
+
+from loguru import logger
+from pathlib import Path
+import pandas as pd
+
+
+class LogType(Enum):
+
+    WORKER_START = 'started, version'
+    REDIS_CONNECTION = 'Listening on vivarium'
+    NODE = 'Launching new job'
+    WORKER_DONE = 'done, quitting'
+    WORKER_KILLED = 'Killing worker'
+
+    SIM_STARTING = 'Starting job'
+    SIM_SETUP_COMPLETE = 'Simulation setup complete'
+    SIM_LOOP_COMPLETE = 'Simulation main loop completed'
+    SIM_AVG_STEP_LENGTH = 'Average step length'
+    SIM_RUN_TIME_COMPLETE = 'Total simulation run time'
+    SIM_ENDING = 'Exiting job'
+
+    NON_ESSENTIAL = ''
+
+    def __init__(self, str_match):
+        self.str_match = str_match
+
+    @classmethod
+    def first_message(cls):
+        return cls.WORKER_START
+
+    def next_acceptable_log_types(self):
+        next_types = {self.WORKER_START: [self.REDIS_CONNECTION, self.WORKER_KILLED],
+                      self.REDIS_CONNECTION: [self.NODE, self.WORKER_DONE, self.WORKER_KILLED],
+                      self.NODE: [self.SIM_STARTING, self.WORKER_KILLED],
+                      self.WORKER_DONE: [],
+                      self.WORKER_KILLED: [],
+                      self.SIM_STARTING: [self.SIM_SETUP_COMPLETE, self.WORKER_KILLED],
+                      self.SIM_SETUP_COMPLETE: [self.SIM_LOOP_COMPLETE, self.WORKER_KILLED],
+                      self.SIM_LOOP_COMPLETE: [self.SIM_AVG_STEP_LENGTH, self.WORKER_KILLED],
+                      self.SIM_AVG_STEP_LENGTH: [self.SIM_RUN_TIME_COMPLETE, self.WORKER_KILLED],
+                      self.SIM_RUN_TIME_COMPLETE: [self.SIM_ENDING, self.WORKER_KILLED],
+                      self.SIM_ENDING: [self.SIM_STARTING, self.WORKER_DONE, self.NODE, self.WORKER_KILLED],
+                      self.NON_ESSENTIAL: [self.WORKER_START, self.REDIS_CONNECTION,  self.NODE, self.WORKER_DONE,
+                                           self.SIM_STARTING, self.SIM_SETUP_COMPLETE, self.SIM_LOOP_COMPLETE,
+                                           self.SIM_AVG_STEP_LENGTH, self.SIM_RUN_TIME_COMPLETE, self.SIM_ENDING,
+                                           self.NON_ESSENTIAL, self.WORKER_KILLED]}
+        return next_types[self]
+
+    @classmethod
+    def classify_log(cls, log_msg):
+        possible = [l for l in cls if l.str_match in log_msg and l is not cls.NON_ESSENTIAL]  # non-essential will match everything, so exclude it unless no other options
+        return possible[0] if possible else cls.NON_ESSENTIAL
+
+
+class LogMessage:
+
+    def __init__(self, log: dict):
+        self.time = pd.Timestamp(log['record']['time']['repr'])
+        self.level = log['record']['level']['name']
+        self.message = log['record']['message']
+        self.exception = log['record']['exception']
+        self.log_type = LogType.classify_log(self.message)
+
+
+class WorkerLog:
+
+    sim_message_data_map = {LogType.SIM_SETUP_COMPLETE: 'setup_time',
+                            LogType.SIM_LOOP_COMPLETE: 'loop_time',
+                            LogType.SIM_AVG_STEP_LENGTH: 'step_time',
+                            LogType.SIM_RUN_TIME_COMPLETE: 'total_time'}
+
+    def __init__(self, file: Path):
+        self.file = file
+        name = file.stem.split('.')  # TODO: validate name is <sge job id>.<task id>.log
+        self.sge_job_id = int(name[0])
+        self.task_id = int(name[1])
+
+    def _load_messages(self):
+        with open(self.file) as f:
+            messages = [LogMessage(json.loads(line)) for line in f]
+        return messages
+
+    def summarize(self) -> (pd.DataFrame, pd.DataFrame):
+        idx = pd.MultiIndex.from_tuples([(self.sge_job_id, self.task_id)], names=('sge_job_id', 'task_id'))
+        worker = pd.DataFrame({'worker_start_time': pd.NaT, 'worker_end_time': pd.NaT, 'node': None,
+                               'worker_killed': 0, 'jobs_assigned': 0, 'jobs_completed': 0,
+                               'num_exceptions': 0, 'abnormalities': [[]]},
+                              index=idx)
+
+        template_sim = pd.DataFrame({'setup_time': None, 'loop_time': None, 'step_time': None,
+                                  'total_time': None, 'job_started': [0], 'job_complete': [0]},
+                                 index=idx)
+        sims = [pd.DataFrame()]
+        sim = template_sim
+        expected_msg_types = [LogType.first_message()]
+
+        messages = self._load_messages()
+        for i, msg in enumerate(messages):
+
+            if msg.exception:
+                warning_msg = f'{msg.exception["type"]} found in log file {self.file.stem} at line {i}.'
+                logger.debug(warning_msg)
+                worker['num_exceptions'] += 1
+
+            if msg.log_type is LogType.NON_ESSENTIAL:  # no need to check
+                continue
+
+            if msg.log_type not in expected_msg_types:
+                # TODO: actually handle this and give user exploration options instead of just warning
+                warning_msg = f'Unexpected message type {msg.log_type} encountered at line {i}. ' \
+                    f'Expecting one of: {[t.name for t in expected_msg_types]}.'
+                logger.debug(f'In {self.file.stem}: ' + warning_msg)
+                worker['abnormalities'] += [warning_msg]
+
+            if msg.log_type is LogType.WORKER_START:
+                worker['worker_start_time'] = msg.time
+            elif msg.log_type is LogType.NODE:
+                worker['node'] = msg.message.split()[-1]
+            elif msg.log_type is LogType.WORKER_KILLED:
+                worker['abnormalities'] += [f'Worker killed with message: {msg.message}.']
+                worker['worker_killed'] = 1
+            elif msg.log_type is LogType.SIM_STARTING:
+                worker['jobs_assigned'] += 1
+                sim['job_started'] = 1
+            elif msg.log_type is LogType.SIM_ENDING:
+                sim['job_complete'] = 1
+                worker['jobs_completed'] += 1
+                sims.append(sim)
+                sim = template_sim
+            elif msg.log_type in self.sim_message_data_map:  # pull out timing info from msg and record
+                sim[self.sim_message_data_map[msg.log_type]] = float(msg.message.split()[-2])
+
+            expected_msg_types = msg.log_type.next_acceptable_log_types()
+
+        if messages:
+            worker['worker_end_time'] = pd.Timestamp(messages[-1].time)
+
+            if expected_msg_types:
+                warning_msg = f'Log file ended unexpectedly. Expecting additional log message(s) ' \
+                    f'of type {" or ".join(expected_msg_types)}.'
+                logger.debug(f'In {self.file.stem}: ' + warning_msg)
+                worker['abnormalities'] += [warning_msg]
+
+            # log has ended without exit msg for last sim (e.g., worker was killed in middle of sim job)
+            if not sim.equals(template_sim):
+                sims.append(sim)
+
+        else:
+            worker['abnormalities'] += [f'Empty log file.']
+            logger.debug(f'Empty log file encountered: {self.file.stem}.')
+
+        return worker, pd.concat(sims)
+
+

--- a/src/vivarium_cluster_tools/log_parser.py
+++ b/src/vivarium_cluster_tools/log_parser.py
@@ -51,7 +51,8 @@ class LogType(Enum):
 
     @classmethod
     def classify_log(cls, log_msg):
-        possible = [l for l in cls if l.str_match in log_msg and l is not cls.NON_ESSENTIAL]  # non-essential will match everything, so exclude it unless no other options
+        # non-essential will match everything, so exclude it unless no other options
+        possible = [l for l in cls if l.str_match in log_msg and l is not cls.NON_ESSENTIAL]
         return possible[0] if possible else cls.NON_ESSENTIAL
 
 
@@ -162,7 +163,7 @@ def parse_log_directory(input_directory: Union[Path, str], output_directory: Uni
     worker_data = []
     sim_data = []
     for i, file in enumerate(log_files):
-        logger.info(f'Parsing file {i} of {len(log_files)}.')
+        logger.info(f'Parsing file {i+1} of {len(log_files)}.')
         w = WorkerLog(file)
         w_d, s_d = w.summarize()
         worker_data.append(w_d)

--- a/src/vivarium_cluster_tools/log_parser.py
+++ b/src/vivarium_cluster_tools/log_parser.py
@@ -154,3 +154,23 @@ class WorkerLog:
         return worker, pd.concat(sims)
 
 
+def parse_log_directory(input_directory: Path, output_directory: Path):
+    log_files = [f for f in input_directory.iterdir()]
+
+    worker_data = []
+    sim_data = []
+    for i, file in enumerate(log_files):
+        logger.info(f'Parsing file {i} of {len(log_files)}.')
+        w = WorkerLog(file)
+        w_d, s_d = w.summarize()
+        worker_data.append(w_d)
+        sim_data.append(s_d)
+
+    worker_data = pd.concat(worker_data)
+    sim_data = pd.concat(sim_data)
+
+    out_file = output_directory / 'log_summary.hdf'
+    worker_data.to_hdf(out_file, key='worker_data')
+    sim_data.to_hdf(out_file, key='sim_data')
+
+    logger.info(f'All log files successfully parsed. Summary hdf can be found at {out_file}.')


### PR DESCRIPTION
Given a worker logs directory, creates a summary hdf with 2 keys: ``worker_data``, at which is a df with one row per worker log and ``sim_data``, at which is a df with one row per simulation job picked up by a worker. See screenshots for examples of what these dfs look like. 

Command to run is e.g.: `` psimulate parse-logs /home/kate/code/tests/log_tests/logs/2019_05_23_11_48_50_run/worker_logs -v``

In testing, it takes 2-3 minutes to parse 3k log files. 

Also @collijk I'm not sure what causes the losing track of workers, but I know what it looks like in the logs now - every worker that was lost has a log message saying it's listening on redis, but never gets any log messages from the distributed worker (or any work) and so shuts down. In the worker_data df, these workers are every row that have 0 jobs assigned (and no node because the node message comes from the distributed worker). 

**worker_data df:**
![image](https://user-images.githubusercontent.com/33732724/58649663-8b5df380-82c1-11e9-8e1c-58d7cbd3ef6e.png)

**sim_data df:**
![image](https://user-images.githubusercontent.com/33732724/58650534-c9f4ad80-82c3-11e9-9ee6-8a5157f9835f.png)

