### PR TITLE
Feature/version validation

### DIFF
--- a/src/vivarium_cluster_tools/runner.py
+++ b/src/vivarium_cluster_tools/runner.py
@@ -328,6 +328,7 @@ def main(model_specification_file, branch_configuration_file, result_directory, 
     output_dir, logging_dirs = utilities.setup_directories(model_specification_file, result_directory,
                                                            restart, expand=(num_input_draws or num_random_seeds))
 
+    utilities.validate_environment(output_dir)
     utilities.configure_master_process_logging_to_file(logging_dirs['main'])
 
     arguments = SimpleNamespace(model_specification_file=model_specification_file,

--- a/src/vivarium_cluster_tools/runner.py
+++ b/src/vivarium_cluster_tools/runner.py
@@ -328,8 +328,8 @@ def main(model_specification_file, branch_configuration_file, result_directory, 
     output_dir, logging_dirs = utilities.setup_directories(model_specification_file, result_directory,
                                                            restart, expand=(num_input_draws or num_random_seeds))
 
-    utilities.validate_environment(output_dir)
     utilities.configure_master_process_logging_to_file(logging_dirs['main'])
+    utilities.validate_environment(output_dir)
 
     arguments = SimpleNamespace(model_specification_file=model_specification_file,
                                 branch_configuration_file=branch_configuration_file,

--- a/src/vivarium_cluster_tools/utilities.py
+++ b/src/vivarium_cluster_tools/utilities.py
@@ -7,6 +7,8 @@ from pathlib import Path
 import sys
 
 from loguru import logger
+from pip._internal.operations import freeze
+from typing import Dict, List, Tuple
 
 from vivarium_cluster_tools import globals as vct_globals
 
@@ -157,3 +159,72 @@ def handle_exceptions(func, with_debugger):
                 raise
 
     return wrapped
+
+def parse_package_version(s: str) -> Tuple[str, str]:
+    if 'no version control' in s:  # installed from non-git controlled source code in editable mode
+        s = s.split('(')[1].split(')')[0] # yields <package>==<version>
+
+    packaged = s.split('==')
+    if len(packaged) == 2:  # not installed from source code, e.g., <package>==<version>
+        package = packaged[0]
+        version = packaged[1]
+    else:  # installed from source code in editable mode so more parsing required
+        sourced = s.split('=')
+        package = sourced[-1]
+        version = sourced[0].split('@')[-1].replace('#egg', '')  # version here is git hash
+    return package, version
+
+
+def convert_pip_list_to_dict(pf_list: List[str]) -> Dict:
+    return {p: v for p, v in [parse_package_version(s) for s in pf_list]}
+
+
+def compare_environments(current: Dict, original: Dict):
+    differences = []
+
+    current_packages = set(current.keys())
+    original_packages = set(original.keys())
+
+    new_packages = current_packages.difference(original_packages)
+    if new_packages:
+        differences.append(
+            f'The current environment contains the following packages not present in the original '
+            f'environment: {new_packages}.')
+
+    missing_packages = original_packages.difference(current_packages)
+    if missing_packages:
+        differences.append(
+            f'The current environment is missing the following packages present in the original '
+            f'environment: {missing_packages}.')
+
+    differing_versions = []
+    for p in current_packages.intersection(original_packages):
+        if current[p] != original[p]:
+            differing_versions.append(f'{p}: {original[p]} -> {current[p]}')
+
+    if differing_versions:
+        differences.append(
+            f'Different versions found in current and original environment for the following '
+            f'packages: {differing_versions}.')
+
+    if differences:
+        differences = "\n".join(differences)
+        raise EnvironmentError(f'Differences found between environment used for original run and current '
+                               f'environment. In order to successfully run, you should make a new environment '
+                               f'using the requirements.txt file found in the output directory. Differences found as '
+                               f'follows: {differences}.')
+
+
+def validate_environment(output_dir: Path):
+    original_environment_file = output_dir / 'requirements.txt'
+
+    current_environment_list = [p for p in freeze.freeze()]
+    if not original_environment_file.exists:  # original run
+        with open(original_environment_file, 'w') as f:
+            f.write('\n'.join(current_environment_list))
+    else:  # compare with original
+        with open(original_environment_file, 'r') as f:
+            original_environment_list = [line.replace('\n', '') for line in f]
+        current_environment = convert_pip_list_to_dict(current_environment_list)
+        original_environment = convert_pip_list_to_dict(original_environment_list)
+        compare_environments(current_environment, original_environment)

--- a/src/vivarium_cluster_tools/utilities.py
+++ b/src/vivarium_cluster_tools/utilities.py
@@ -8,6 +8,7 @@ import sys
 
 from loguru import logger
 from typing import Dict, List, Tuple
+# depending on version of pip, freeze may be in one of two places
 try:
     from pip._internal.operations import freeze
 except ImportError:
@@ -223,11 +224,14 @@ def validate_environment(output_dir: Path):
 
     current_environment_list = [p for p in freeze.freeze()]
     if not original_environment_file.exists():  # original run
-        with open(original_environment_file, 'w') as f:
+        with original_environment_file.open('w') as f:
             f.write('\n'.join(current_environment_list))
     else:  # compare with original
-        with open(original_environment_file, 'r') as f:
+        with original_environment_file.open('r') as f:
             original_environment_list = [line.replace('\n', '') for line in f]
         current_environment = convert_pip_list_to_dict(current_environment_list)
         original_environment = convert_pip_list_to_dict(original_environment_list)
         compare_environments(current_environment, original_environment)
+        logger.info('Validation of environment successful. All pip installed packages match '
+                    'original versions. Run can proceed.')
+

--- a/src/vivarium_cluster_tools/utilities.py
+++ b/src/vivarium_cluster_tools/utilities.py
@@ -7,8 +7,11 @@ from pathlib import Path
 import sys
 
 from loguru import logger
-from pip._internal.operations import freeze
 from typing import Dict, List, Tuple
+try:
+    from pip._internal.operations import freeze
+except ImportError:
+    from pip.operations import freeze
 
 from vivarium_cluster_tools import globals as vct_globals
 

--- a/src/vivarium_cluster_tools/utilities.py
+++ b/src/vivarium_cluster_tools/utilities.py
@@ -213,10 +213,9 @@ def compare_environments(current: Dict, original: Dict):
 
     if differences:
         differences = "\n".join(differences)
-        raise EnvironmentError(f'Differences found between environment used for original run and current '
-                               f'environment. In order to successfully run, you should make a new environment '
-                               f'using the requirements.txt file found in the output directory. Differences found as '
-                               f'follows: {differences}.')
+        raise ValueError(f'Differences found between environment used for original run and current environment. '
+                         f'In order to successfully run, you should make a new environment using the requirements.txt '
+                         f'file found in the output directory. Differences found as follows: {differences}.')
 
 
 def validate_environment(output_dir: Path):

--- a/src/vivarium_cluster_tools/utilities.py
+++ b/src/vivarium_cluster_tools/utilities.py
@@ -163,9 +163,10 @@ def handle_exceptions(func, with_debugger):
 
     return wrapped
 
+
 def parse_package_version(s: str) -> Tuple[str, str]:
     if 'no version control' in s:  # installed from non-git controlled source code in editable mode
-        s = s.split('(')[1].split(')')[0] # yields <package>==<version>
+        s = s.split('(')[1].split(')')[0]  # yields <package>==<version>
 
     packaged = s.split('==')
     if len(packaged) == 2:  # not installed from source code, e.g., <package>==<version>
@@ -222,7 +223,7 @@ def validate_environment(output_dir: Path):
     original_environment_file = output_dir / 'requirements.txt'
 
     current_environment_list = [p for p in freeze.freeze()]
-    if not original_environment_file.exists:  # original run
+    if not original_environment_file.exists():  # original run
         with open(original_environment_file, 'w') as f:
             f.write('\n'.join(current_environment_list))
     else:  # compare with original


### PR DESCRIPTION
on first run, saves environment to requirements.txt. on subsequent runs, compares current environment to original. If mismatches, you'll see an error like the following:

![image](https://user-images.githubusercontent.com/33732724/58735363-07823500-83af-11e9-97ac-531a741632d1.png)
