### PR TITLE
Feature/add runtime option

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -19,8 +19,9 @@ shared_options = [
                  default='24:00:00',
                  help=('The estimated maximum runtime (DD:HH:MM) of the simulation jobs. '
                        'By default, the cluster will terminate jobs after 24h regardless of '
-                       'queue. The maximum supported runtime is 3 days. Keep in mind that runtimes '
-                       'by node vary wildly.')),
+                       'queue. The maximum supported runtime is 3 days. Keep in mind that the '
+                       'session you are launching from must be able to live at least as long '
+                       'as the simulation jobs, and that runtimes by node vary wildly.')),
     click.option('--pdb', 'with_debugger',
                  is_flag=True,
                  help='Drop into python debugger if an error occurs.'),

--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -14,7 +14,7 @@ shared_options = [
                  default=3,
                  help=('The estimated maximum memory usage in GB of an individual simulate job. '
                        'The simulations will be run with this as a limit.')),
-    click.option('--runtime', '-r',
+    click.option('--max-runtime', '-r',
                  type=str,
                  default='24:00:00',
                  help=('The estimated maximum runtime (DD:HH:MM) of the simulation jobs. '

--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -14,6 +14,13 @@ shared_options = [
                  default=3,
                  help=('The estimated maximum memory usage in GB of an individual simulate job. '
                        'The simulations will be run with this as a limit.')),
+    click.option('--runtime', '-r',
+                 type=str,
+                 default='24:00:00',
+                 help=('The estimated maximum runtime (DD:HH:MM) of the simulation jobs. '
+                       'By default, the cluster will terminate jobs after 24h, regardless of '
+                       'Queue. The maximum supported runtime is 3 days. Keep in mind, runtimes '
+                       'by node vary wildly.')),
     click.option('--pdb', 'with_debugger',
                  is_flag=True,
                  help='Drop into python debugger if an error occurs.'),
@@ -76,7 +83,7 @@ def run(model_specification, branch_configuration, result_directory, **options):
     main = handle_exceptions(runner.main, logger, options['with_debugger'])
 
     main(model_specification, branch_configuration, result_directory,
-         options['project'], options['peak_memory'],
+         options['project'], options['peak_memory'], options['max_runtime'],
          redis_processes=options['redis'], no_batch=options['no_batch'])
 
 
@@ -95,7 +102,7 @@ def restart(results_root, **options):
     main = handle_exceptions(runner.main, logger, options['with_debugger'])
 
     main(None, None, results_root,
-         options['project'], options['peak_memory'],
+         options['project'], options['peak_memory'], options['max_runtime'],
          redis_processes=options['redis'], restart=True, no_batch=options['no_batch'])
 
 
@@ -118,7 +125,7 @@ def expand(results_root, **options):
     main = handle_exceptions(runner.main, logger, options['with_debugger'])
 
     main(None, None, results_root,
-         options['project'], options['peak_memory'],
+         options['project'], options['peak_memory'], options['max_runtime'],
          redis_processes=options['redis'],
          restart=True,
          expand={'num_draws': options['add_draws'],

--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -18,8 +18,8 @@ shared_options = [
                  type=str,
                  default='24:00:00',
                  help=('The estimated maximum runtime (DD:HH:MM) of the simulation jobs. '
-                       'By default, the cluster will terminate jobs after 24h, regardless of '
-                       'Queue. The maximum supported runtime is 3 days. Keep in mind, runtimes '
+                       'By default, the cluster will terminate jobs after 24h regardless of '
+                       'queue. The maximum supported runtime is 3 days. Keep in mind that runtimes '
                        'by node vary wildly.')),
     click.option('--pdb', 'with_debugger',
                  is_flag=True,

--- a/src/vivarium_cluster_tools/psimulate/utilities.py
+++ b/src/vivarium_cluster_tools/psimulate/utilities.py
@@ -139,11 +139,11 @@ def get_valid_project(project, cluster):
     return project
 
 
-def get_uge_specification(peak_memory, project, job_name):
+def get_uge_specification(peak_memory, max_runtime, project, job_name):
     cluster_name = get_cluster_name()
     project = get_valid_project(project, cluster_name)
 
-    preamble = f'-w n -q all.q -l m_mem_free={peak_memory}G -N {job_name}'
+    preamble = f'-w n -q all.q -l m_mem_free={peak_memory}G -N {job_name} -l h_rt={max_runtime}'
 
     if cluster_name == "cluster-fair":
         preamble += " -l fthread=1"


### PR DESCRIPTION
This adds a command line option that maps to the h_rt resource on the cluster. This lets a user run jobs longer than 24 hrs. The cluster default is 24 hours and jobs are reaped at that point.
