### PR TITLE
bugfix/determine correct queue based on max runtime

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/globals.py
+++ b/src/vivarium_cluster_tools/psimulate/globals.py
@@ -6,3 +6,7 @@ CLUSTER_PROJECTS = ['proj_cost_effect', 'proj_cost_effect_diarrhea', 'proj_cost_
 DEFAULT_CLUSTER_PROJECT = 'proj_cost_effect'
 DEFAULT_OUTPUT_DIRECTORY = '/share/costeffectiveness/results'
 DEFAULT_JOBS_PER_REDIS_INSTANCE = 1000
+
+# Cluster specific parameters
+ALL_Q_MAX_RUNTIME_HOURS = 3 * 24
+LONG_Q_MAX_RUNTIME_HOURS = 16 * 24

--- a/src/vivarium_cluster_tools/psimulate/utilities.py
+++ b/src/vivarium_cluster_tools/psimulate/utilities.py
@@ -139,6 +139,17 @@ def get_valid_project(project, cluster):
     return project
 
 
+def get_valid_queue(max_runtime):
+    hours, minutes, seconds = max_runtime.split(":")
+    runtime_in_hours = int(hours) + float(minutes) / 60. + float(seconds) / 3600.
+    if runtime_in_hours <= vct_globals.ALL_Q_MAX_RUNTIME_HOURS:
+        return 'all.q'
+    elif runtime_in_hours <= vct_globals.LONG_Q_MAX_RUNTIME_HOURS:
+        return 'long.q'
+    else:
+        raise ValueError(f"Max runtime value too large. Must be less than {vct_globals.LONG_Q_MAX_RUNTIME_HOURS}h.")
+
+
 def get_uge_specification(peak_memory, max_runtime, project, job_name):
     cluster_name = get_cluster_name()
     project = get_valid_project(project, cluster_name)

--- a/src/vivarium_cluster_tools/psimulate/utilities.py
+++ b/src/vivarium_cluster_tools/psimulate/utilities.py
@@ -153,8 +153,8 @@ def get_valid_queue(max_runtime):
 def get_uge_specification(peak_memory, max_runtime, project, job_name):
     cluster_name = get_cluster_name()
     project = get_valid_project(project, cluster_name)
-
-    preamble = f'-w n -q all.q -l m_mem_free={peak_memory}G -N {job_name} -l h_rt={max_runtime}'
+    queue = get_valid_queue(max_runtime)
+    preamble = f'-w n -q {queue} -l m_mem_free={peak_memory}G -N {job_name} -l h_rt={max_runtime}'
 
     if cluster_name == "cluster-fair":
         preamble += " -l fthread=1"

--- a/src/vivarium_cluster_tools/psimulate/utilities.py
+++ b/src/vivarium_cluster_tools/psimulate/utilities.py
@@ -140,7 +140,11 @@ def get_valid_project(project, cluster):
 
 
 def get_valid_queue(max_runtime):
-    hours, minutes, seconds = max_runtime.split(":")
+    runtime_args = max_runtime.split(":")
+    if len(runtime_args) != 3:
+        raise ValueError("Invalid --max-runtime supplied. Format should be hh:mm:ss.")
+    else:
+        hours, minutes, seconds = runtime_args
     runtime_in_hours = int(hours) + float(minutes) / 60. + float(seconds) / 3600.
     if runtime_in_hours <= vct_globals.ALL_Q_MAX_RUNTIME_HOURS:
         return 'all.q'


### PR DESCRIPTION
the cluster has two queues with runtime limits. the runtime dictates the correct queue. we weren't handling long runtimes or invalid runtimes