### PR TITLE
add queue and priority flags

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -138,8 +138,8 @@ class RunContext:
         self.cluster_project = arguments.project
         self.peak_memory = arguments.peak_memory
         self.max_runtime = arguments.max_runtime
-        self.priority = arguments.priority,
-        self.queue = arguments.queue,
+        self.priority = arguments.priority
+        self.queue = arguments.queue
         self.number_already_completed = 0
         self.output_directory = arguments.output_directory
         self.job_name = arguments.output_directory.parts[-2]  # The model specification name.

--- a/src/vivarium_cluster_tools/psimulate/utilities.py
+++ b/src/vivarium_cluster_tools/psimulate/utilities.py
@@ -4,7 +4,6 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-import click
 from loguru import logger
 from typing import Dict, List, Tuple
 # depending on version of pip, freeze may be in one of two places
@@ -237,7 +236,7 @@ def validate_environment(output_dir: Path):
                     'original versions. Run can proceed.')
 
 
-def validate_queue(queue: str, max_runtime: str) -> queue:
+def validate_queue(queue: str, max_runtime: str):
     valid_queue = get_valid_queue(max_runtime)
     if queue is None:
         return valid_queue


### PR DESCRIPTION
Added support for specifying queue and priority, and rearranged some validation / help strings. Priority is validated against cluster-defined limits and queue's default is set dynamically based on runtime.