### PR TITLE
Add atexit handlers to cleanup dir when psimulate produces no output.hdf

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -370,6 +370,8 @@ def main(model_specification_file: str, branch_configuration_file: str, result_d
 
     output_dir, logging_dirs = utilities.setup_directories(model_specification_file, result_directory,
                                                            restart, expand=bool(num_input_draws or num_random_seeds))
+    atexit.register(utilities.check_for_empty_results_dir, output_dir=output_dir)
+    atexit.register(lambda: logger.remove())
 
     native_specification['job_name'] = output_dir.parts[-2]
     native_specification = NativeSpecification(**native_specification)

--- a/src/vivarium_cluster_tools/psimulate/utilities.py
+++ b/src/vivarium_cluster_tools/psimulate/utilities.py
@@ -2,6 +2,7 @@ import os
 import sys
 from datetime import datetime
 from pathlib import Path
+from shutil import rmtree
 
 from loguru import logger
 from typing import Dict, List, Sequence
@@ -185,3 +186,9 @@ def validate_environment(output_dir: Path):
         compare_environments(current_environment, original_environment)
         logger.info('Validation of environment successful. All pip installed packages match '
                     'original versions. Run can proceed.')
+
+
+def check_for_empty_results_dir(output_dir: Path):
+    results_file = output_dir / 'output.hdf'
+    if not results_file.exists():
+        rmtree(output_dir)


### PR DESCRIPTION
Add atexit handlers to cleanup dir when psimulate produces no output.hdf

This change adds two atexit handlers: one to check for the presence of an output.hdf file as an indication of success/failure, cleaning up the results directory for the run if no output.hdf is present. Another atexit handler is added to stop logging, which if left running, will leave NFS locks in the results directory, preventing removal.

This change was tested simulating a failed psimulate run by specifying a bogus artifact_path in the yaml file. A successful invocation was run using proper settings. In both cases, the changes performed as expected. It's worth nothing however that in the successful psimulate run, upon inspecting the output.hdf preserved by this change, there were 2 failures out of 2000. These failures must be unrelated to this atexit change.