### PR TITLE
MIC-2171: Added worker log timing messages and prototype cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ if __name__ == "__main__":
             [console_scripts]
             psimulate=vivarium_cluster_tools.psimulate.cli:psimulate
             vparse=vivarium_cluster_tools.vparse.cli:vparse
+            vipin=vivarium_cluster_tools.vipin.cli:vipin
         """,
 
         install_requires=install_requires,

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,8 @@ if __name__ == "__main__":
         'rq>=1.0, <=1.2.2',
         'vivarium>=0.9.3',
         'click',
+        'psutil',
+        'requests'
     ]
 
     test_requirements = [

--- a/src/vivarium_cluster_tools/psimulate/distributed_worker.py
+++ b/src/vivarium_cluster_tools/psimulate/distributed_worker.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 import math
 import os
 from pathlib import Path
@@ -197,7 +198,7 @@ def worker(parameters: Mapping):
         logger.info(f'Total simulation run time {exec_time["total_minutes"]:.3f} minutes.')
 
         # Write out debug JSON line for easy log parsing
-        logger.debug({
+        logger.debug(json.dumps({
             "host": os.environ['HOSTNAME'].split('.')[0],
             "job_number": os.environ['JOB_ID'],
             "task_number": os.environ['SGE_TASK_ID'],
@@ -206,8 +207,8 @@ def worker(parameters: Mapping):
             "scenario": parameters['branch_configuration'],  # assumes leaves of branch config tree are scenarios
             "event": event,
             "exec_time": exec_time,
-            "counters": end_snapshot-start_snapshot
-        })
+            "counters": (end_snapshot-start_snapshot).to_dict()
+        }))
 
         idx = pd.MultiIndex.from_tuples([(input_draw, random_seed)], names=['input_draw_number', 'random_seed'])
         output_metrics = pd.DataFrame(metrics, index=idx)

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -394,8 +394,8 @@ def main(model_specification_file: str, branch_configuration_file: str, result_d
 
     output_dir, logging_dirs = utilities.setup_directories(model_specification_file, result_directory,
                                                            restart, expand=bool(num_input_draws or num_random_seeds))
- # XXXX
- #   atexit.register(utilities.check_for_empty_results_dir, output_dir=output_dir)
+
+    atexit.register(utilities.check_for_empty_results_dir, output_dir=output_dir)
     atexit.register(lambda: logger.remove())
 
     native_specification['job_name'] = output_dir.parts[-2]

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -144,7 +144,9 @@ def init_job_template(jt, native_specification: NativeSpecification, sge_log_dir
     export VIVARIUM_LOGGING_DIRECTORY={worker_log_directory}
     export PYTHONPATH={output_dir}:$PYTHONPATH
 
-    {shutil.which('rq')} worker -c {worker_settings_file.stem} --name ${{JOB_ID}}.${{SGE_TASK_ID}} --burst -w "vivarium_cluster_tools.psimulate.distributed_worker.ResilientWorker" --exception-handler "vivarium_cluster_tools.psimulate.distributed_worker.retry_handler" vivarium
+    {shutil.which('rq')} worker -c {worker_settings_file.stem} --name ${{JOB_ID}}.${{SGE_TASK_ID}} --burst \
+        -w "vivarium_cluster_tools.psimulate.distributed_worker.ResilientWorker" \
+        --exception-handler "vivarium_cluster_tools.psimulate.distributed_worker.retry_handler" vivarium
 
     ''')
     launcher.close()
@@ -281,7 +283,7 @@ def build_job_list(ctx: RunContext) -> List[dict]:
 
 def concat_preserve_types(df_list: List[pd.DataFrame]) -> pd.DataFrame:
     """Concatenation preserves all ``numpy`` dtypes but does not preserve any
-    pandas speciifc dtypes (e.g., categories become objects."""
+    pandas specific dtypes (e.g., categories become objects."""
     dtypes = df_list[0].dtypes
     columns_by_dtype = [list(dtype_group.index) for _, dtype_group in dtypes.groupby(dtypes)]
 
@@ -392,7 +394,8 @@ def main(model_specification_file: str, branch_configuration_file: str, result_d
 
     output_dir, logging_dirs = utilities.setup_directories(model_specification_file, result_directory,
                                                            restart, expand=bool(num_input_draws or num_random_seeds))
-    atexit.register(utilities.check_for_empty_results_dir, output_dir=output_dir)
+ # XXXX
+ #   atexit.register(utilities.check_for_empty_results_dir, output_dir=output_dir)
     atexit.register(lambda: logger.remove())
 
     native_specification['job_name'] = output_dir.parts[-2]

--- a/src/vivarium_cluster_tools/vipin/cli.py
+++ b/src/vivarium_cluster_tools/vipin/cli.py
@@ -1,0 +1,26 @@
+import click
+
+from vivarium_cluster_tools.vipin import utilities, log_parser
+
+@click.command()
+@click.argument('logs-directory', type=click.Path(exists=True, file_okay=False))
+@click.option('--result-directory', '-o', type=click.Path(exists=True, file_okay=False),
+              help='The directory into which to write the summary of the parsed logs. '
+                   'Defaults to given logs directory if not given.')
+@click.option('--hdf/--csv', default=False,
+              help='Choose hdf or csv for output data. Defaults to csv.')
+@click.option('--sample', '-s', type=int, help='Randomly sample a number of worker logs.')
+@click.option('-v', 'verbose', count=True, help='Configure logging verbosity.')
+def vipin(logs_directory, result_directory, hdf, sample, verbose):
+    """Get performance information from worker_logs from a ``psimulate`` command.
+
+    Given a worker logs directory from a previous run, a summary hdf will be
+    created in the ``result_directory`` (which defaults to the given logs
+    directory unless otherwise specified) with two keys: 'worker_data', which
+    includes a summary line for each worker log in the directory and 'sim_data',
+    which includes a summary line for each simulation job run by a worker.
+    """
+    utilities.configure_master_process_logging_to_terminal(verbose)
+    if not result_directory:
+        result_directory = logs_directory
+    log_parser.parse_log_directory(logs_directory, result_directory, hdf, sample)

--- a/src/vivarium_cluster_tools/vipin/log_parser.py
+++ b/src/vivarium_cluster_tools/vipin/log_parser.py
@@ -65,7 +65,7 @@ def parse_log_directory(input_directory: Union[Path, str], output_directory: Uni
     # Get jobapi data about the job
     try:
         job_numbers = worker_df['job_number'].unique()
-        assert(job_numbers == 1)
+        assert(len(job_numbers) == 1)
         jobapi_data = requests.get("http://jobapi.ihme.washington.edu/fair/queryjobids",
                          params=[('job_number', job_numbers[0]), ('limit', 50000)]).json()
         jobapi_df = pd.DataFrame(jobapi_data["data"])
@@ -74,7 +74,7 @@ def parse_log_directory(input_directory: Union[Path, str], output_directory: Uni
     except Exception as e:
         logger.warning(f'Job API request failed with {e}')
 
-    worker_df = worker_df.set_index(['host', 'job_id', 'task_id', 'draw', 'seed', 'scenario'])
+    worker_df = worker_df.set_index(['host', 'job_number', 'task_number', 'draw', 'seed', 'scenario'])
 
     logger.info("\nStatistics by scenario:")
     for col in [col for col in worker_df.columns if col.startswith('exec_time_')]:

--- a/src/vivarium_cluster_tools/vipin/log_parser.py
+++ b/src/vivarium_cluster_tools/vipin/log_parser.py
@@ -20,7 +20,7 @@ class WorkerLog:
 
     def get_summaries(self) -> dict:
         """Get all performance summary log messages in WorkerLog"""
-        telemetry_pattern = re.compile(r'^\{\'host\'.+\'job_number\'.+\}$')
+        telemetry_pattern = re.compile(r'^\{\"host\".+\"job_number\".+\}$')
 
         # Ideally we'd only need to look at the tail of the file, but because a worker can do multiple draws, we need
         # to iterate over all the lines...
@@ -31,7 +31,7 @@ class WorkerLog:
             message = json.loads(line)['record']['message']
             m = telemetry_pattern.fullmatch(str(message))
             if m:
-                yield json_normalize(message, sep='_')
+                yield json_normalize(json.loads(message), sep='_')
         f.close()
 
 

--- a/src/vivarium_cluster_tools/vipin/log_parser.py
+++ b/src/vivarium_cluster_tools/vipin/log_parser.py
@@ -1,0 +1,76 @@
+from loguru import logger
+from pathlib import Path
+from random import sample
+import pandas as pd
+import json
+import re
+from pandas.io.json import json_normalize
+from typing import Union
+
+
+class WorkerLog:
+
+    def __init__(self, file: Path):
+        self.file = file
+        name = file.stem.split('.')  # TODO: validate name is <sge job id>.<task id>.log
+        self.sge_job_id = int(name[0])
+        self.task_id = int(name[1])
+
+    def get_summaries(self) -> dict:
+        """Get all performance summary log messages in WorkerLog"""
+        telemetry_pattern = re.compile(r'^\{\'host\'.+\'job_id\'.+\}$')
+
+        # Ideally we'd only need to look at the tail of the file, but because a worker can do multiple draws, we need
+        # to iterate over all the lines...
+        # TODO: either change worker to cut a new log for each draw and check tail reversed(list(log))
+        #  *OR* parallelize this
+        f = self.file.open('r')
+        for line in f.readlines():
+            message = json.loads(line)['record']['message']
+            m = telemetry_pattern.fullmatch(str(message))
+            if m:
+                yield json_normalize(message, sep='_')
+        f.close()
+
+
+def parse_log_directory(input_directory: Union[Path, str], output_directory: Union[Path, str], output_hdf: bool,
+                        random_draw: int = 0):
+    input_directory, output_directory = Path(input_directory), Path(output_directory)
+    worker_log_pattern = re.compile(r'^([0-9]+)\.([0-9]+)\.log$')
+    log_files = [f for f in input_directory.iterdir() if worker_log_pattern.fullmatch(f.name)]
+
+    if random_draw:
+        log_files = sample(log_files, random_draw)
+
+    worker_data = []
+    for i, file in enumerate(log_files):
+        logger.info(f'Parsing file {i+1} of {len(log_files)}.')
+        log = WorkerLog(file)
+        for item in log.get_summaries():
+            worker_data.append(item)
+    worker_df = pd.concat(worker_data)
+
+    # Convert the Unix timestamps to datetimes
+    for col in [col for col in worker_df.columns if col.startswith("event_")]:
+        worker_df[col] = pd.to_datetime(worker_df[col], unit='s')
+
+    # Simplify name of scenario normalized JSON label
+    scenario_label = [col for col in worker_df.columns if 'scenario' in col]
+    assert(len(scenario_label) == 1)
+    worker_df = worker_df.rename(columns={scenario_label[0]: 'scenario'})
+
+    worker_df = worker_df.set_index(['host', 'job_id', 'task_id', 'draw', 'seed', 'scenario'])
+
+    logger.info("\nStatistics by scenario:")
+    for col in [col for col in worker_df.columns if col.startswith('exec_time_')]:
+        logger.info(f'\n>>> {col}:\n{worker_df.groupby("scenario")[col].agg(["mean", "std", "min", "max"])}')
+
+    # Write to file
+    out_file = output_directory / 'log_summary'
+    if output_hdf:
+        out_file = out_file.with_suffix(".hdf")
+        worker_df.to_hdf(out_file, key='worker_data')
+    else:
+        out_file = out_file.with_suffix(".csv")
+        worker_df.to_csv(out_file)
+    logger.info(f'All log files successfully parsed. Summary {"hdf" if output_hdf else "csv"} can be found at {out_file}.')

--- a/src/vivarium_cluster_tools/vipin/perf_counters.py
+++ b/src/vivarium_cluster_tools/vipin/perf_counters.py
@@ -1,0 +1,31 @@
+import psutil
+from time import time
+
+
+class CounterSnapshot:
+    def __init__(self, cpu=None, disk=None, freq=None, net=None, timestamp=None):
+        self.cpu = psutil.cpu_stats() if cpu is None else cpu
+        self.disk = psutil.disk_io_counters(perdisk=False, nowrap=True) if disk is None else disk
+        self.freq = psutil.cpu_freq(percpu=False) if freq is None else freq
+        self.net = psutil.net_io_counters(pernic=False, nowrap=True) if net is None else net
+        self.timestamp = time() if timestamp is None else timestamp
+
+    def __sub__(self, other):
+        cpu = type(other.cpu)(*tuple(self.cpu[i] - other.cpu[i] for i in range(len(other.cpu))))
+        disk = type(other.disk)(*tuple(self.disk[i] - other.disk[i] for i in range(len(other.disk))))
+        # FIXME: Do something other than get difference of current frequency? Take average?
+        freq = type(other.freq)(*tuple((self.freq[i] + other.freq[i])/2 for i in range(len(other.freq))))
+        # freq = type(other.freq)(*tuple(self.freq[i] - other.freq[i] for i in range(len(other.freq))))
+        # freq = other.freq
+        net = type(other.net)(*tuple(self.net[i] - other.net[i] for i in range(len(other.net))))
+        timestamp = self.timestamp - other.timestamp
+        return CounterSnapshot(cpu, disk, freq, net, timestamp)
+
+    def __repr__(self) -> str:
+        c_dict = dict()
+        c_dict["cpu"] = dict(self.cpu._asdict())
+        c_dict["freq"] = dict(self.freq._asdict())
+        c_dict["disk"] = dict(self.disk._asdict())
+        c_dict["net"] = dict(self.net._asdict())
+        c_dict["time"] = self.timestamp
+        return f"{c_dict}"

--- a/src/vivarium_cluster_tools/vipin/perf_counters.py
+++ b/src/vivarium_cluster_tools/vipin/perf_counters.py
@@ -1,3 +1,4 @@
+import json
 import psutil
 from time import time
 
@@ -10,22 +11,22 @@ class CounterSnapshot:
         self.net = psutil.net_io_counters(pernic=False, nowrap=True) if net is None else net
         self.timestamp = time() if timestamp is None else timestamp
 
-    def __sub__(self, other):
-        cpu = type(other.cpu)(*tuple(self.cpu[i] - other.cpu[i] for i in range(len(other.cpu))))
-        disk = type(other.disk)(*tuple(self.disk[i] - other.disk[i] for i in range(len(other.disk))))
-        # FIXME: Do something other than get difference of current frequency? Take average?
-        freq = type(other.freq)(*tuple((self.freq[i] + other.freq[i])/2 for i in range(len(other.freq))))
-        # freq = type(other.freq)(*tuple(self.freq[i] - other.freq[i] for i in range(len(other.freq))))
-        # freq = other.freq
-        net = type(other.net)(*tuple(self.net[i] - other.net[i] for i in range(len(other.net))))
-        timestamp = self.timestamp - other.timestamp
-        return CounterSnapshot(cpu, disk, freq, net, timestamp)
-
-    def __repr__(self) -> str:
+    def to_dict(self):
         c_dict = dict()
         c_dict["cpu"] = dict(self.cpu._asdict())
         c_dict["freq"] = dict(self.freq._asdict())
         c_dict["disk"] = dict(self.disk._asdict())
         c_dict["net"] = dict(self.net._asdict())
         c_dict["time"] = self.timestamp
-        return f"{c_dict}"
+        return c_dict
+
+    def __sub__(self, other):
+        cpu = type(other.cpu)(*tuple(self.cpu[i] - other.cpu[i] for i in range(len(other.cpu))))
+        disk = type(other.disk)(*tuple(self.disk[i] - other.disk[i] for i in range(len(other.disk))))
+        freq = type(other.freq)(*tuple((self.freq[i] + other.freq[i]) / 2 for i in range(len(other.freq))))
+        net = type(other.net)(*tuple(self.net[i] - other.net[i] for i in range(len(other.net))))
+        timestamp = self.timestamp - other.timestamp
+        return CounterSnapshot(cpu, disk, freq, net, timestamp)
+
+    def __repr__(self) -> str:
+        return json.dumps(self.to_dict())

--- a/src/vivarium_cluster_tools/vipin/utilities.py
+++ b/src/vivarium_cluster_tools/vipin/utilities.py
@@ -1,0 +1,18 @@
+import sys
+
+from loguru import logger
+
+
+def add_logging_sink(sink, verbose, colorize=False, serialize=False):
+    message_format = ('<green>{time:YYYY-MM-DD HH:mm:ss.SSS}</green> | '
+                      '<cyan>{name}</cyan>:<cyan>{function}</cyan>:<cyan>{line}</cyan> '
+                      '- <level>{message}</level>')
+    if verbose == 0:
+        logger.add(sink, colorize=colorize, level="INFO", format=message_format, serialize=serialize)
+    elif verbose >= 1:
+        logger.add(sink, colorize=colorize, level="DEBUG", format=message_format, serialize=serialize)
+
+
+def configure_master_process_logging_to_terminal(verbose):
+    logger.remove()  # Clear default configuration
+    add_logging_sink(sys.stdout, verbose, colorize=True)


### PR DESCRIPTION
This change adds additional timing messages in the worker logs for
setup, simulant initialization, etc., and a final JSON-formatted
telemetry string to be logged for each simulation draw.

This also adds a new tool called "vipin", which is meant to parse
the telemetry strings and other information to produce a csv (or
hdf) of all worker log performance telemetry and log some basic
stats about the psimulate run.

Tested on a full SR Cervical Cancer run v6.0, and produced expected
output.