### PR TITLE
MIC-2298: Add no_cleanup option to avoid auto delete on failure

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -44,7 +44,11 @@ shared_options = [
                  help='Configure logging verbosity.'),
     click.option('--no-batch',
                  is_flag=True,
-                 help="Don't batch results, write them as they come in.")
+                 help="Don't batch results, write them as they come in."),
+    click.option('--no-cleanup',
+                 is_flag=True,
+                 hidden=True,
+                 help="Hidden developer option, if flagged, don't automatically cleanup results directory on failure.")
 ]
 
 
@@ -97,7 +101,7 @@ def run(model_specification, branch_configuration, result_directory, **options):
           'queue': options['queue'],
           'peak_memory': options['peak_memory'],
           'max_runtime': options['max_runtime']},
-         redis_processes=options['redis'], no_batch=options['no_batch'])
+         redis_processes=options['redis'], no_batch=options['no_batch'], no_cleanup=options['no_cleanup'])
 
 
 @psimulate.command()
@@ -119,7 +123,7 @@ def restart(results_root, **options):
           'queue': options['queue'],
           'peak_memory': options['peak_memory'],
           'max_runtime': options['max_runtime']},
-         redis_processes=options['redis'], restart=True, no_batch=options['no_batch'])
+         redis_processes=options['redis'], restart=True, no_batch=options['no_batch'], no_cleanup=options['no_cleanup'])
 
 
 @psimulate.command()
@@ -149,4 +153,5 @@ def expand(results_root, **options):
          restart=True,
          expand={'num_draws': options['add_draws'],
                  'num_seeds': options['add_seeds']},
-         no_batch=options['no_batch'])
+         no_batch=options['no_batch'],
+         no_cleanup=options['no_cleanup'])

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -382,13 +382,15 @@ def check_user_sge_config():
 def main(model_specification_file: str, branch_configuration_file: str, result_directory: str,
          native_specification: dict, redis_processes: int, num_input_draws: int = None,
          num_random_seeds: int = None, restart:  bool = False,
-         expand: Dict[str, int] = None, no_batch: bool = False):
+         expand: Dict[str, int] = None, no_batch: bool = False, no_cleanup: bool = False):
 
     utilities.exit_if_on_submit_host(utilities.get_hostname())
 
     output_dir, logging_dirs = utilities.setup_directories(model_specification_file, result_directory,
                                                            restart, expand=bool(num_input_draws or num_random_seeds))
-    atexit.register(utilities.check_for_empty_results_dir, output_dir=output_dir)
+    if not no_cleanup:
+        atexit.register(utilities.check_for_empty_results_dir, output_dir=output_dir)
+
     atexit.register(lambda: logger.remove())
 
     native_specification['job_name'] = output_dir.parts[-2]


### PR DESCRIPTION
This adds a --no-cleanup option that prevents psimulate from
automatically removing the results directory. The option is aimed
at developers who may have to debug simulation failures run through
psimulate. The option is hidden (not in help output) because its
not aimed at general use.

Tested with a cancer site simulation with added bogus function
calls. Logs were preserved (or not) as expected.