### PR TITLE
add command line argument to specify artifact path to psimulate

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -4,10 +4,12 @@ import yaml
 import numpy as np
 from pathlib import Path
 
+from vivarium.framework.configuration import ConfigurationError
 from vivarium.framework.utilities import collapse_nested_dict
 
+from vivarium_cluster_tools.psimulate import globals as vct_globals
 
-ARTIFACT_PATH_KEY = 'input_data.artifact_path'
+FULL_ARTIFACT_PATH_KEY = f'{vct_globals.INPUT_DATA_KEY}.{vct_globals.ARTIFACT_PATH_KEY}'
 
 
 class Keyspace:
@@ -69,6 +71,23 @@ class Keyspace:
         existing = self._keyspace['random_seed']
         additional = calculate_random_seeds(num_seeds, existing)
         self._keyspace['random_seed'] = existing + additional
+
+    def set_artifact_path(self, artifact_path: str):
+        if FULL_ARTIFACT_PATH_KEY in self._keyspace:
+            raise ConfigurationError(
+                'Artifact path already set. Most likely cause is trying to specify path in both the branch '
+                'specification file and a command line argument.', artifact_path)
+
+        if not Path(artifact_path).exists():
+            raise FileNotFoundError(f"Cannot find artifact at path {artifact_path}")
+
+        self._keyspace[FULL_ARTIFACT_PATH_KEY] = artifact_path
+
+        for branch in self.branches:
+            if vct_globals.INPUT_DATA_KEY in branch:
+                branch[vct_globals.INPUT_DATA_KEY][vct_globals.ARTIFACT_PATH_KEY] = artifact_path
+            else:
+                branch[vct_globals.INPUT_DATA_KEY] = {vct_globals.ARTIFACT_PATH_KEY: artifact_path}
 
     def __iter__(self):
         """Yields and individual simulation configuration from the keyspace."""
@@ -159,7 +178,7 @@ def calculate_keyspace(branches):
         if set(branch.keys()) != set(keyspace.keys()):
             raise ValueError("All branches must have the same keys")
         for k, v in branch.items():
-            if k == ARTIFACT_PATH_KEY:
+            if k == FULL_ARTIFACT_PATH_KEY:
                 validate_artifact_path(v)
             keyspace[k].add(v)
     keyspace = {k: list(v) for k, v in keyspace.items()}

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -4,7 +4,6 @@ import yaml
 import numpy as np
 from pathlib import Path
 
-from vivarium.framework.configuration import ConfigurationError
 from vivarium.framework.utilities import collapse_nested_dict
 
 from vivarium_cluster_tools.psimulate import globals as vct_globals
@@ -71,23 +70,6 @@ class Keyspace:
         existing = self._keyspace['random_seed']
         additional = calculate_random_seeds(num_seeds, existing)
         self._keyspace['random_seed'] = existing + additional
-
-    def set_artifact_path(self, artifact_path: str):
-        if FULL_ARTIFACT_PATH_KEY in self._keyspace:
-            raise ConfigurationError(
-                'Artifact path already set. Most likely cause is trying to specify path in both the branch '
-                'specification file and a command line argument.', artifact_path)
-
-        if not Path(artifact_path).exists():
-            raise FileNotFoundError(f"Cannot find artifact at path {artifact_path}")
-
-        self._keyspace[FULL_ARTIFACT_PATH_KEY] = artifact_path
-
-        for branch in self.branches:
-            if vct_globals.INPUT_DATA_KEY in branch:
-                branch[vct_globals.INPUT_DATA_KEY][vct_globals.ARTIFACT_PATH_KEY] = artifact_path
-            else:
-                branch[vct_globals.INPUT_DATA_KEY] = {vct_globals.ARTIFACT_PATH_KEY: artifact_path}
 
     def __iter__(self):
         """Yields and individual simulation configuration from the keyspace."""

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -71,6 +71,10 @@ class Keyspace:
         additional = calculate_random_seeds(num_seeds, existing)
         self._keyspace['random_seed'] = existing + additional
 
+    def __contains__(self, item):
+        """Checks whether the item is present in the Keyspace"""
+        return item in self._keyspace
+
     def __iter__(self):
         """Yields and individual simulation configuration from the keyspace."""
         for job_config in product(self._keyspace['input_draw'], self._keyspace['random_seed'], self.branches):

--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -69,16 +69,24 @@ def psimulate():
 @psimulate.command()
 @click.argument('model_specification', type=click.Path(exists=True, dir_okay=False))
 @click.argument('branch_configuration', type=click.Path(exists=True, dir_okay=False))
+@click.option('--artifact_path', '-i', type=click.Path(resolve_path=True), help='The path to the artifact data file.')
 @click.option('--result-directory', '-o', type=click.Path(exists=True, file_okay=False), default=None,
               help='The directory to write results to. A folder will be created in this directory with the same name '
                    'as the configuration file.')
 @pass_shared_options
-def run(model_specification, branch_configuration, result_directory, **options):
+def run(model_specification, branch_configuration, artifact_path, result_directory, **options):
     """Run a parallel simulation.
 
     The simulation itself is defined by a MODEL_SPECIFICATION yaml file
     and the parameter changes across runs are defined by a BRANCH_CONFIGURATION
     yaml file.
+
+    The path to the data artifact can be provided as an argument here, in the
+    branch configuration, or in the model specification file. Values provided as
+    a command line argument or in the branch specification file will override a
+    value specified in the model specifications file. If an artifact path is
+    provided both as a command line argument and to the branch configuration file
+    a ConfigurationError will be thrown.
 
     If a results directory is provided, a subdirectory will be created with the
     same name as the MODEL_SPECIFICATION if one does not exist. Results will be
@@ -92,7 +100,7 @@ def run(model_specification, branch_configuration, result_directory, **options):
     utilities.configure_master_process_logging_to_terminal(options['verbose'])
     main = handle_exceptions(runner.main, logger, options['with_debugger'])
 
-    main(model_specification, branch_configuration, result_directory,
+    main(model_specification, branch_configuration, artifact_path, result_directory,
          {'project': options['project'],
           'queue': options['queue'],
           'peak_memory': options['peak_memory'],

--- a/src/vivarium_cluster_tools/psimulate/distributed_worker.py
+++ b/src/vivarium_cluster_tools/psimulate/distributed_worker.py
@@ -17,6 +17,8 @@ from rq.job import JobStatus
 from rq.worker import Worker, StopRequested
 from rq.registry import FailedJobRegistry
 
+from vivarium_cluster_tools.psimulate import globals as vct_globals
+
 
 def retry_handler(job, *exc_info):
     retries = job.meta.get('remaining_retries', 2)
@@ -130,8 +132,10 @@ def worker(parameters: Mapping):
         input_data_config = {
             'input_draw_number': input_draw,
         }
-        if 'artifact_path' in branch_config.get('input_data'):
-            input_data_config.update({'artifact_path': branch_config['input_data']['artifact_path']})
+        if vct_globals.ARTIFACT_PATH_KEY in dict(branch_config).get(vct_globals.INPUT_DATA_KEY, {}):
+            input_data_config.update({
+                vct_globals.ARTIFACT_PATH_KEY: branch_config[vct_globals.INPUT_DATA_KEY][vct_globals.ARTIFACT_PATH_KEY]
+            })
 
         configuration.update({
             'run_configuration': {
@@ -144,7 +148,7 @@ def worker(parameters: Mapping):
                 'random_seed': random_seed,
                 'additional_seed': input_draw,
             },
-            'input_data': input_data_config
+            vct_globals.INPUT_DATA_KEY: input_data_config
         })
 
         sim = SimulationContext(model_specification_file, configuration=configuration)

--- a/src/vivarium_cluster_tools/psimulate/globals.py
+++ b/src/vivarium_cluster_tools/psimulate/globals.py
@@ -16,3 +16,8 @@ LONG_Q_MAX_RUNTIME_HOURS = 16 * 24
 
 CLUSTER_ENV_HOSTNAME = 'HOSTNAME'
 SUBMIT_HOST_MARKER = '-submit-'
+
+
+# Configuration key constants
+INPUT_DATA_KEY = 'input_data'
+ARTIFACT_PATH_KEY = 'artifact_path'

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -25,9 +25,9 @@ drmaa = utilities.get_drmaa()
 
 
 class RunContext:
-    def __init__(self, model_specification_file: str, branch_configuration_file: str, output_directory: Path,
-                 logging_directories: Dict[str, Path], num_input_draws: int, num_random_seeds: int,
-                 restart: bool, expand: Dict[str, int], no_batch: bool):
+    def __init__(self, model_specification_file: str, branch_configuration_file: str, artifact_path: str,
+                 output_directory: Path, logging_directories: Dict[str, Path], num_input_draws: int,
+                 num_random_seeds: int, restart: bool, expand: Dict[str, int], no_batch: bool):
         self.number_already_completed = 0
         self.output_directory = output_directory
         self.no_batch = no_batch
@@ -47,7 +47,9 @@ class RunContext:
             self.keyspace = Keyspace.from_branch_configuration(num_input_draws, num_random_seeds,
                                                                branch_configuration_file)
 
-            if "artifact_path" in model_specification.configuration.input_data:
+            if artifact_path:
+                self.keyspace.set_artifact_path(artifact_path)
+            elif "artifact_path" in model_specification.configuration.input_data:
                 artifact_path = parse_artifact_path_config(model_specification.configuration)
                 model_specification.configuration.input_data.update(
                     {"artifact_path": artifact_path},
@@ -379,7 +381,7 @@ def check_user_sge_config():
                                    "with the worker logs.")
 
 
-def main(model_specification_file: str, branch_configuration_file: str, result_directory: str,
+def main(model_specification_file: str, branch_configuration_file: str, artifact_path: str, result_directory: str,
          native_specification: dict, redis_processes: int, num_input_draws: int = None,
          num_random_seeds: int = None, restart:  bool = False,
          expand: Dict[str, int] = None, no_batch: bool = False):
@@ -397,7 +399,7 @@ def main(model_specification_file: str, branch_configuration_file: str, result_d
     utilities.configure_master_process_logging_to_file(logging_dirs['main'])
     utilities.validate_environment(output_dir)
 
-    ctx = RunContext(model_specification_file, branch_configuration_file, output_dir, logging_dirs,
+    ctx = RunContext(model_specification_file, branch_configuration_file, artifact_path, output_dir, logging_dirs,
                      num_input_draws, num_random_seeds, restart, expand, no_batch)
     check_user_sge_config()
     jobs = build_job_list(ctx)

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -34,7 +34,6 @@ class RunContext:
                  num_random_seeds: int, restart: bool, expand: Dict[str, int], no_batch: bool):
         self.number_already_completed = 0
         self.output_directory = output_directory
-        self.model_specification = self.output_directory / MODEL_SPEC_FILENAME
         self.no_batch = no_batch
         self.sge_log_directory = logging_directories['sge']
         self.worker_log_directory = logging_directories['worker']
@@ -66,13 +65,14 @@ class RunContext:
                     {vct_globals.ARTIFACT_PATH_KEY: artifact_path},
                     source=__file__)
 
-            with open(self.model_specification, 'w') as config_file:
+            with open(self.output_directory / MODEL_SPEC_FILENAME, 'w') as config_file:
                 yaml.dump(model_specification.to_dict(), config_file)
 
             self.existing_outputs = None
 
             # Log some basic stuff about the simulation to be run.
             self.keyspace.persist(self.output_directory)
+        self.model_specification = self.output_directory / MODEL_SPEC_FILENAME
 
 
 class NativeSpecification:


### PR DESCRIPTION
Tested following scenarios:

Specifying artifact in command line, but not branches file -> Success
Specifying artifact in branches file, but not command line -> Success
Specifying artifact in both command line and branches file -> ConfigurationError

The last commit `1c1d446` fixes a redis `ConnectionError`, but I have no idea why defining `self.model_specification` at the end makes any difference. When I inspected it in the debugger, it was identical before and after the change, but it consistently fails when defining `self.model_specification` at in the block at the beginning of the method and consistently succeeds when defining it at the end.

One other note: writing out the model spec as we are doing here by turning it into a `dict` and then dumping it to yaml is not actually a no-op, though it should be as far as functionality goes. The differences are that all commented lines are lost, tabs are two spaces, while we tend to usually use four spaces, and the order of keys is not preserved.