### PR TITLE
MIC-2307: Add single worker log for all performance log messages

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/distributed_worker.py
+++ b/src/vivarium_cluster_tools/psimulate/distributed_worker.py
@@ -191,7 +191,7 @@ def worker(parameters: Mapping):
         event['end'] = time()
         end_snapshot = CounterSnapshot()
 
-        do_sim_epilogue(end_snapshot, event, exec_time, parameters, start_snapshot)
+        do_sim_epilogue(start_snapshot, end_snapshot, event, exec_time, parameters)
 
         idx = pd.MultiIndex.from_tuples([(input_draw, random_seed)], names=['input_draw_number', 'random_seed'])
         output_metrics = pd.DataFrame(metrics, index=idx)
@@ -210,7 +210,7 @@ def worker(parameters: Mapping):
         logger.info('Exiting job: {}'.format((input_draw, random_seed, model_specification_file, branch_config)))
 
 
-def do_sim_epilogue(end_snapshot, event, exec_time, parameters, start_snapshot):
+def do_sim_epilogue(start: CounterSnapshot, end: CounterSnapshot, event: dict, exec_time: dict, parameters:dict):
     exec_time['results_minutes'] = (event['end'] - event["results_start"]) / 60
     logger.info(f'Results reporting completed in {exec_time["results_minutes"]:.3f} minutes.')
     exec_time['total_minutes'] = (event['end'] - event["start"]) / 60
@@ -228,6 +228,6 @@ def do_sim_epilogue(end_snapshot, event, exec_time, parameters, start_snapshot):
         "scenario": parameters['branch_configuration'],  # assumes leaves of branch config tree are scenarios
         "event": event,
         "exec_time": exec_time,
-        "counters": (end_snapshot - start_snapshot).to_dict()
+        "counters": (end - start).to_dict()
     }))
     logger.remove(perf_log)

--- a/src/vivarium_cluster_tools/psimulate/distributed_worker.py
+++ b/src/vivarium_cluster_tools/psimulate/distributed_worker.py
@@ -191,24 +191,7 @@ def worker(parameters: Mapping):
         event['end'] = time()
         end_snapshot = CounterSnapshot()
 
-        exec_time['results_minutes'] = (event['end'] - event["results_start"]) / 60
-        logger.info(f'Results reporting completed in {exec_time["results_minutes"]:.3f} minutes.')
-        exec_time['total_minutes'] = (event['end'] - event["start"]) / 60
-
-        logger.info(f'Total simulation run time {exec_time["total_minutes"]:.3f} minutes.')
-
-        # Write out debug JSON line for easy log parsing
-        logger.debug(json.dumps({
-            "host": os.environ['HOSTNAME'].split('.')[0],
-            "job_number": os.environ['JOB_ID'],
-            "task_number": os.environ['SGE_TASK_ID'],
-            "draw": parameters['input_draw'],
-            "seed": parameters['random_seed'],
-            "scenario": parameters['branch_configuration'],  # assumes leaves of branch config tree are scenarios
-            "event": event,
-            "exec_time": exec_time,
-            "counters": (end_snapshot-start_snapshot).to_dict()
-        }))
+        do_sim_epilogue(end_snapshot, event, exec_time, parameters, start_snapshot)
 
         idx = pd.MultiIndex.from_tuples([(input_draw, random_seed)], names=['input_draw_number', 'random_seed'])
         output_metrics = pd.DataFrame(metrics, index=idx)
@@ -225,3 +208,26 @@ def worker(parameters: Mapping):
         raise
     finally:
         logger.info('Exiting job: {}'.format((input_draw, random_seed, model_specification_file, branch_config)))
+
+
+def do_sim_epilogue(end_snapshot, event, exec_time, parameters, start_snapshot):
+    exec_time['results_minutes'] = (event['end'] - event["results_start"]) / 60
+    logger.info(f'Results reporting completed in {exec_time["results_minutes"]:.3f} minutes.')
+    exec_time['total_minutes'] = (event['end'] - event["start"]) / 60
+    logger.info(f'Total simulation run time {exec_time["total_minutes"]:.3f} minutes.')
+
+    # Write out debug JSON line to shared performance log
+    perf_log = logger.add(Path(os.environ['VIVARIUM_LOGGING_DIRECTORY']) / 'performance.log', level='DEBUG',
+                          serialize=True, enqueue=True)
+    logger.debug(json.dumps({
+        "host": os.environ['HOSTNAME'].split('.')[0],
+        "job_number": os.environ['JOB_ID'],
+        "task_number": os.environ['SGE_TASK_ID'],
+        "draw": parameters['input_draw'],
+        "seed": parameters['random_seed'],
+        "scenario": parameters['branch_configuration'],  # assumes leaves of branch config tree are scenarios
+        "event": event,
+        "exec_time": exec_time,
+        "counters": (end_snapshot - start_snapshot).to_dict()
+    }))
+    logger.remove(perf_log)

--- a/src/vivarium_cluster_tools/vipin/cli.py
+++ b/src/vivarium_cluster_tools/vipin/cli.py
@@ -9,9 +9,8 @@ from vivarium_cluster_tools.vipin import utilities, log_parser
                    'Defaults to given logs directory if not given.')
 @click.option('--hdf/--csv', default=False,
               help='Choose hdf or csv for output data. Defaults to csv.')
-@click.option('--sample', '-s', type=int, help='Randomly sample a number of worker logs.')
 @click.option('-v', 'verbose', count=True, help='Configure logging verbosity.')
-def vipin(logs_directory, result_directory, hdf, sample, verbose):
+def vipin(logs_directory, result_directory, hdf, verbose):
     """Get performance information from worker_logs from a ``psimulate`` command.
 
     Given a worker logs directory from a previous run, a summary hdf will be
@@ -23,4 +22,4 @@ def vipin(logs_directory, result_directory, hdf, sample, verbose):
     utilities.configure_master_process_logging_to_terminal(verbose)
     if not result_directory:
         result_directory = logs_directory
-    log_parser.parse_log_directory(logs_directory, result_directory, hdf, sample)
+    log_parser.parse_log_directory(logs_directory, result_directory, hdf)

--- a/src/vivarium_cluster_tools/vipin/log_parser.py
+++ b/src/vivarium_cluster_tools/vipin/log_parser.py
@@ -1,6 +1,5 @@
 from loguru import logger
 from pathlib import Path
-from random import sample
 import numpy as np
 import pandas as pd
 import json
@@ -10,82 +9,68 @@ from typing import Union
 import requests
 
 
-class WorkerLog:
-
+class PerformanceLog:
     def __init__(self, file: Path):
         self.file = file
-        name = file.stem.split('.')  # TODO: validate name is <sge job id>.<task id>.log
-        self.sge_job_id = int(name[0])
-        self.task_id = int(name[1])
+        self.count = 0
 
     def get_summaries(self) -> dict:
-        """Get all performance summary log messages in WorkerLog"""
-        telemetry_pattern = re.compile(r'^\{\"host\".+\"job_number\".+\}$')
+        """Get all performance summary log messages in PerformanceLog"""
+        telemetry_pattern = re.compile(r'^{\"host\".+\"job_number\".+}$')
 
-        # Ideally we'd only need to look at the tail of the file, but because a worker can do multiple draws, we need
-        # to iterate over all the lines...
-        # TODO: either change worker to cut a new log for each draw and check tail reversed(list(log))
-        #  *OR* parallelize this
+        self.count = 0
         f = self.file.open('r')
         for line in f.readlines():
             message = json.loads(line)['record']['message']
             m = telemetry_pattern.fullmatch(str(message))
             if m:
+                self.count += 1
                 yield json_normalize(json.loads(message), sep='_')
         f.close()
 
 
-def parse_log_directory(input_directory: Union[Path, str], output_directory: Union[Path, str], output_hdf: bool,
-                        random_draw: int = 0):
+def parse_log_directory(input_directory: Union[Path, str], output_directory: Union[Path, str], output_hdf: bool):
     input_directory, output_directory = Path(input_directory), Path(output_directory)
-    worker_log_pattern = re.compile(r'^([0-9]+)\.([0-9]+)\.log$')
-    log_files = [f for f in input_directory.iterdir() if worker_log_pattern.fullmatch(f.name)]
+    perf_log = PerformanceLog(Path(input_directory / 'performance.log'))
 
-    if random_draw:
-        log_files = sample(log_files, random_draw)
-
-    worker_data = []
-    for i, file in enumerate(log_files):
-        # TODO: set up tdqm progress bar
-        logger.info(f'Parsing file {i+1} of {len(log_files)}.')
-        log = WorkerLog(file)
-        for item in log.get_summaries():
-            worker_data.append(item)
-    worker_df = pd.concat(worker_data)
+    perf_data = []
+    for item in perf_log.get_summaries():
+        perf_data.append(item)
+    perf_df = pd.concat(perf_data)
 
     # Convert the Unix timestamps to datetimes
-    for col in [col for col in worker_df.columns if col.startswith("event_")]:
-        worker_df[col] = pd.to_datetime(worker_df[col], unit='s')
+    for col in [col for col in perf_df.columns if col.startswith("event_")]:
+        perf_df[col] = pd.to_datetime(perf_df[col], unit='s')
 
     # Simplify name of scenario normalized JSON label
-    scenario_label = [col for col in worker_df.columns if 'scenario' in col]
-    assert(len(scenario_label) == 1)
-    worker_df = worker_df.rename(columns={scenario_label[0]: 'scenario'})
+    # TODO: add expansion of scenario values
+    scenario_label = [col for col in perf_df.columns if 'scenario' in col]
+    perf_df = perf_df.rename(columns={scenario_label[0]: 'scenario'})
 
     # Get jobapi data about the job
     try:
-        job_numbers = worker_df['job_number'].unique()
+        job_numbers = perf_df['job_number'].unique()
         assert(len(job_numbers) == 1)
         jobapi_data = requests.get("http://jobapi.ihme.washington.edu/fair/queryjobids",
                          params=[('job_number', job_numbers[0]), ('limit', 50000)]).json()
         jobapi_df = pd.DataFrame(jobapi_data["data"])
-        worker_df = worker_df.astype({'job_number': np.int64, 'task_number': np.int64})
-        worker_df = worker_df.merge(jobapi_df, on=['job_number', 'task_number'])
+        perf_df = perf_df.astype({'job_number': np.int64, 'task_number': np.int64})
+        perf_df = perf_df.merge(jobapi_df, on=['job_number', 'task_number'])
     except Exception as e:
         logger.warning(f'Job API request failed with {e}')
 
-    worker_df = worker_df.set_index(['host', 'job_number', 'task_number', 'draw', 'seed', 'scenario'])
+    perf_df = perf_df.set_index(['host', 'job_number', 'task_number', 'draw', 'seed', 'scenario'])
 
     logger.info("\nStatistics by scenario:")
-    for col in [col for col in worker_df.columns if col.startswith('exec_time_')]:
-        logger.info(f'\n>>> {col}:\n{worker_df.groupby("scenario")[col].agg(["mean", "std", "min", "max"])}')
+    for col in [col for col in perf_df.columns if col.startswith('exec_time_')]:
+        logger.info(f'\n>>> {col}:\n{perf_df.groupby("scenario")[col].agg(["mean", "std", "min", "max"])}')
 
     # Write to file
     out_file = output_directory / 'log_summary'
     if output_hdf:
         out_file = out_file.with_suffix(".hdf")
-        worker_df.to_hdf(out_file, key='worker_data')
+        perf_df.to_hdf(out_file, key='worker_data')
     else:
         out_file = out_file.with_suffix(".csv")
-        worker_df.to_csv(out_file)
-    logger.info(f'All log files successfully parsed. Summary {"hdf" if output_hdf else "csv"} can be found at {out_file}.')
+        perf_df.to_csv(out_file)
+    logger.info(f'Performance summary {"hdf" if output_hdf else "csv"} can be found at {out_file}.')


### PR DESCRIPTION
This change adds a single worker log for all workers to write
the JSON-formatted performance summary log messages to, for
consumption by vipin.

Tested against a real workload (LSFF) with performance.log and
vipin output looking as expected.