### PR TITLE
Feature/mic 2290 complex scenario logging

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/distributed_worker.py
+++ b/src/vivarium_cluster_tools/psimulate/distributed_worker.py
@@ -209,15 +209,15 @@ def worker(parameters: Mapping):
         logger.info('Exiting job: {}'.format((input_draw, random_seed, model_specification_file, branch_config)))
 
 
-def do_sim_epilogue(start: CounterSnapshot, end: CounterSnapshot, event: dict, exec_time: dict, parameters:dict):
+def do_sim_epilogue(start: CounterSnapshot, end: CounterSnapshot, event: dict, exec_time: dict, parameters: Mapping):
     exec_time['results_minutes'] = (event['end'] - event["results_start"]) / 60
     logger.info(f'Results reporting completed in {exec_time["results_minutes"]:.3f} minutes.')
     exec_time['total_minutes'] = (event['end'] - event["start"]) / 60
     logger.info(f'Total simulation run time {exec_time["total_minutes"]:.3f} minutes.')
 
-    # Write out debug JSON line to shared performance log
-    perf_log = logger.add(Path(os.environ['VIVARIUM_LOGGING_DIRECTORY']) / 'performance.log', level='DEBUG',
-                          serialize=True, enqueue=True)
+    perf_log = logger.add(
+        Path(os.environ['VIVARIUM_LOGGING_DIRECTORY']) / f'perf.{os.environ["JOB_ID"]}.{os.environ["SGE_TASK_ID"]}.log',
+        level='DEBUG', serialize=True)
     logger.debug(json.dumps({
         "host": os.environ['HOSTNAME'].split('.')[0],
         "job_number": os.environ['JOB_ID'],

--- a/src/vivarium_cluster_tools/vipin/cli.py
+++ b/src/vivarium_cluster_tools/vipin/cli.py
@@ -14,15 +14,13 @@ from vivarium_cluster_tools.vipin import utilities, perf_report
 def vipin(logs_directory, result_directory, hdf, verbose):
     """Get performance information from worker_logs from a ``psimulate`` command.
 
-    Given a worker logs directory from a previous run, a summary hdf will be
+    Given a worker logs directory from a previous run, a summary csv will be
     created in the ``result_directory`` (which defaults to the given logs
-    directory unless otherwise specified) with two keys: 'worker_data', which
-    includes a summary line for each worker log in the directory and 'sim_data',
-    which includes a summary line for each simulation job run by a worker.
+    directory unless otherwise specified).
     """
     utilities.configure_master_process_logging_to_terminal(verbose)
     if not result_directory:
         result_directory = logs_directory
 
-    perf_report.report_performance(logs_directory, result_directory, hdf)
+    perf_report.report_performance(logs_directory, result_directory, hdf, verbose)
 

--- a/src/vivarium_cluster_tools/vipin/perf_report.py
+++ b/src/vivarium_cluster_tools/vipin/perf_report.py
@@ -119,7 +119,8 @@ def print_stat_report(perf_df: pd.DataFrame, scenario_cols: list):
             '\n').split('\n')
         for col in [col for col in perf_df.columns if col.startswith('exec_time_')]:
             logger.info(
-                f"""\n>>> {col} over compound scenario:\n({"/".join(scenario_cols)}):
+                f"""\n>>> {col} over compound scenario:\n({"/".join(
+                    [s.replace('scenario_', '') for s in scenario_cols])}):
                 \n{perf_df.groupby("compound_scenario")[col].agg(["mean", "std", "min", "max"])}""")
 
 

--- a/src/vivarium_cluster_tools/vipin/perf_report.py
+++ b/src/vivarium_cluster_tools/vipin/perf_report.py
@@ -94,8 +94,12 @@ def report_performance(input_directory: Union[Path, str], output_directory: Unio
 
     # Set index to include branch configuration/scenario columns
     index_cols = BASE_PERF_INDEX_COLS
-    index_cols.extend([col for col in perf_df.columns if col.startswith("scenario_")])
+    scenario_cols = [col for col in perf_df.columns if col.startswith("scenario_")]
+    index_cols.extend(scenario_cols)
     perf_df = perf_df.set_index(index_cols)
+
+    for col in [col for col in perf_df.columns if col.startswith('exec_time_')]:
+        logger.info(f'\n>>> {col}:\n{perf_df.groupby(scenario_cols)[col].agg(["mean", "std", "min", "max"])}')
 
     # Write to file
     out_file = output_directory / 'log_summary'

--- a/src/vivarium_cluster_tools/vipin/perf_report.py
+++ b/src/vivarium_cluster_tools/vipin/perf_report.py
@@ -10,39 +10,51 @@ from loguru import logger
 from pandas.io.json import json_normalize
 
 
-class PerformanceLog:
-    """
-    A class to implement a getter for data in the workers' performance log.
+BASE_PERF_INDEX_COLS = ['host', 'job_number', 'task_number', 'draw', 'seed']
 
-    Given a Path, a PerformanceLog clase provides a generator to get at each
-    entry in the workers' performance log. The class also provides a method
-    to get all entries in a pd.DataFrame. Because there is a single log for
-    a run's performance, this class is intended as a singleton.
+
+class PerformanceSummary:
+    """
+    A class to implement a getter for data in the workers' performance logs.
+
+    Given a Path, a PerformanceSummary class provides a generator to get at each
+    entry in the workers' performance logs. The class also provides a method
+    to get all entries in a pd.DataFrame. This class is intended as a singleton
+    to provide data about a single Vivarium simulation run.
 
     Attributes
     ----------
-    file : Path
-        Path of log file
+    log_dir : Path
+        Path of log_dir
 
     Methods
     -------
     get_summaries():
-        Generator to retrieve entries in the performance log as dict objects.
+        Generator to retrieve entries in the performance logs as dict objects.
     to_df():
         Returns the performance log data as a pd.DataFrame.
     """
 
-    def __init__(self, file: Path):
-        self.file = file
+    def __init__(self, log_dir: Path):
+        self.log_dir: Path = log_dir
+        self.errors: int = 0
 
     def get_summaries(self) -> dict:
-        """Generator to get all performance summary log messages in PerformanceLog"""
-        with self.file.open('r') as f:
-            for line in f.readlines():
-                message = json.loads(line)['record']['message']
-                m = self.TELEMETRY_PATTERN.fullmatch(str(message))
-                if m:
-                    yield json_normalize(json.loads(message), sep='_')
+        """Generator to get all performance summary log messages in PerformanceSummary"""
+        for log in [f for f in self.log_dir.iterdir() if self.PERF_LOG_PATTERN.fullmatch(f.name)]:
+            with log.open('r') as f:
+                count: int = 0
+                for line in f.readlines():
+                    count += 1
+                    try:
+                        message = json.loads(line)['record']['message']
+                    except Exception as e:
+                        logger.warning(f"Exception: {e}. Malformed message in {log} line {count}, skipping...")
+                        self.errors += 1
+                        continue
+                    m = self.TELEMETRY_PATTERN.fullmatch(str(message))
+                    if m:
+                        yield json_normalize(json.loads(message), sep='_')
 
     def to_df(self) -> pd.DataFrame:
         perf_data = []
@@ -54,21 +66,19 @@ class PerformanceLog:
         for col in [col for col in perf_df.columns if col.startswith("event_")]:
             perf_df[col] = pd.to_datetime(perf_df[col], unit='s')
 
-        # Simplify name of scenario normalized JSON label
-        # TODO: add expansion of scenario values
-        scenario_label = [col for col in perf_df.columns if 'scenario' in col]
-        perf_df = perf_df.rename(columns={scenario_label[0]: 'scenario'})
-
+        # Remove trailing "_scenario" from normalized label
+        perf_df.columns = perf_df.columns.str.replace('_scenario', '', regex=False)
         return perf_df
 
     TELEMETRY_PATTERN = re.compile(r'^{\"host\".+\"job_number\".+}$')
+    PERF_LOG_PATTERN = re.compile(r'^perf\.([0-9]+)\.([0-9]+)\.log$')
 
 
 def report_performance(input_directory: Union[Path, str], output_directory: Union[Path, str], output_hdf: bool):
     input_directory, output_directory = Path(input_directory), Path(output_directory)
-    perf_log = PerformanceLog(input_directory / 'performance.log')
+    perf_summary = PerformanceSummary(input_directory)
 
-    perf_df = perf_log.to_df()
+    perf_df = perf_summary.to_df()
 
     # Get jobapi data about the job
     try:
@@ -82,11 +92,10 @@ def report_performance(input_directory: Union[Path, str], output_directory: Unio
     except Exception as e:
         logger.warning(f'Job API request failed with {e}')
 
-    perf_df = perf_df.set_index(['host', 'job_number', 'task_number', 'draw', 'seed', 'scenario'])
-
-    logger.info("\nStatistics by scenario:")
-    for col in [col for col in perf_df.columns if col.startswith('exec_time_')]:
-        logger.info(f'\n>>> {col}:\n{perf_df.groupby("scenario")[col].agg(["mean", "std", "min", "max"])}')
+    # Set index to include branch configuration/scenario columns
+    index_cols = BASE_PERF_INDEX_COLS
+    index_cols.extend([col for col in perf_df.columns if col.startswith("scenario_")])
+    perf_df = perf_df.set_index(index_cols)
 
     # Write to file
     out_file = output_directory / 'log_summary'
@@ -96,4 +105,8 @@ def report_performance(input_directory: Union[Path, str], output_directory: Unio
     else:
         out_file = out_file.with_suffix(".csv")
         perf_df.to_csv(out_file)
-    logger.info(f'Performance summary {"hdf" if output_hdf else "csv"} can be found at {out_file}.')
+
+    if perf_summary.errors > 0:
+        logger.warning(f'{perf_summary.errors} log row{"s were" if perf_summary.errors > 1 else " was"} unreadable.')
+    logger.info(f'Performance summary {"hdf" if output_hdf else "csv"} can be found at {out_file}, with '
+                f'{perf_df.shape[0]} row{"s" if perf_df.shape[0] > 1 else ""}.')


### PR DESCRIPTION
This change adds more robust handling of scenario columns,
allowing for grid mapped scenarios to be captured in the
output. It also switches from a shared worker performance
log to using per-worker performance logs with names of the
form `perf.job_id.task_id.log`.

If verbosity is set (`-v`), a brief report of the distribution of
execution times by scenario. For complex grid mapped
scenarios, the report shortens the scenario to a `/`-delimited
string.

```
2021-03-24 19:46:58.958 | vivarium_cluster_tools.vipin.perf_report:print_stat_report:124 - 
>>> exec_time_total_minutes over compound scenario:
(female_attendance_multiplier/female_mean_sojourn_time_multiplier/over_40_female_incidence_multiplier/overdiagnosis_factor/scale_up_coverage_target/scale_up_end_year/screening_algorithm):
                
                                        mean   std    min    max
compound_scenario                                               
1.69/1.0/1/1.14/0.15/2025/alternative 344.28 40.06 267.99 414.63
1.69/1.0/1/1.14/0.15/2030/alternative 340.30 50.55 236.35 385.71
1.69/1.0/1/1.14/0.15/2035/alternative 352.25 36.82 267.08 390.43
1.69/1.0/1/1.14/0.15/2040/alternative 351.68 27.56 293.84 386.50
1.69/1.0/1/1.14/0.4/2025/alternative  344.33 45.89 272.69 381.97
1.69/1.0/1/1.14/0.4/2030/alternative  361.60 37.49 272.86 411.24
.
.
.
```

A simple report (single baseline scenario) looks like:

```
2021-03-24 18:34:29.017 | vivarium_cluster_tools.vipin.perf_report:print_stat_report:115 - 
>>> exec_time_total_minutes:
                      mean   std   min   max
scenario_branch_name                        
baseline             75.78 10.69 58.75 91.37
```

Tested with multiple real workloads' logs on the cluster.