### PR TITLE
remove references to msgpack

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/distributed_worker.py
+++ b/src/vivarium_cluster_tools/psimulate/distributed_worker.py
@@ -196,8 +196,7 @@ def worker(parameters: Mapping):
         output_metrics = pd.DataFrame(metrics, index=idx)
         for k, v in collapse_nested_dict(run_key):
             output_metrics[k] = v
-        output = [output_metrics.to_msgpack()]
-        return output
+        return output_metrics
 
     except Exception:
         logger.exception('Unhandled exception in worker')

--- a/src/vivarium_cluster_tools/psimulate/registry.py
+++ b/src/vivarium_cluster_tools/psimulate/registry.py
@@ -129,7 +129,7 @@ class QueueManager:
         result = None
         if job is not None:
             start = time.time()
-            result = pd.read_msgpack(job.result[0])
+            result = job.result
             end = time.time()
             self._logger.debug(f'Read {job_id} from msgpack from queue {self.name} in {end - start:.2f}s.')
             self._status['finished'] += 1

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -333,7 +333,7 @@ def write_results_batch(ctx: RunContext, written_results: pd.DataFrame, unwritte
             results_to_write.to_hdf(temp_output_path, 'data')
             temp_output_path.replace(output_path)
             break
-        except Exception as e:
+        except Exception:
             logger.warning(f'Error trying to write results to hdf, retries remaining {retries}')
             sleep(30)
             retries -= 1
@@ -400,6 +400,7 @@ def try_run_vipin(log_path: Path):
         report_performance(input_directory=log_path, output_directory=log_path, output_hdf=False, verbose=1)
     except Exception as e:
         logger.warning(f'Performance reporting failed with: {e}')
+
 
 def main(model_specification_file: str, branch_configuration_file: str, artifact_path: str, result_directory: str,
          native_specification: dict, redis_processes: int, num_input_draws: int = None,


### PR DESCRIPTION
As James hypothesized, simply returning the `DataFrame` works just fine. 

I tested this initially by commenting out the entire distributed worker and just returning a `DataFrame`, and then by running model 1 of `vivarium_ciff_sam` with the duration only a few timesteps, and both worked fine. 