### PR TITLE
allow psimulate to create result root directories

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -86,7 +86,7 @@ def psimulate():
 @click.argument('model_specification', type=click.Path(exists=True, dir_okay=False))
 @click.argument('branch_configuration', type=click.Path(exists=True, dir_okay=False))
 @click.option('--artifact_path', '-i', type=click.Path(resolve_path=True), help='The path to the artifact data file.')
-@click.option('--result-directory', '-o', type=click.Path(exists=True, file_okay=False), default=None,
+@click.option('--result-directory', '-o', type=click.Path(file_okay=False), default=None,
               help='The directory to write results to. A folder will be created in this directory with the same name '
                    'as the configuration file.')
 @pass_shared_options


### PR DESCRIPTION
Tested by running with ciff and a non-existent results directory. Most of the work done to make this happen had already happened with the addition of `vct_utils.mkdir` but the click flag was incorrect here. 

Now you no longer have to manually create a directory to send the runs to, as it will get created with the correct permissions.