### PR TITLE
MIC-2360 save redis logs to log directory

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -193,13 +193,16 @@ def get_random_free_port() -> int:
     return port
 
 
-def launch_redis(port: int) -> subprocess.Popen:
+def launch_redis(port: int, logging_dirs: Dict) -> subprocess.Popen:
+    log = open(f'{logging_dirs["main"]}/redis.log', 'a')
+    log.write(f'>>>>>>>> Starting log for redis-server on port {port}\n')
+    log.flush()
     try:
         # inline config for redis server.
         redis_process = subprocess.Popen(["redis-server", "--port", f"{port}",
                                           "--timeout", "2",
-                                          "--protected-mode", "no"], stdout=subprocess.DEVNULL,
-                                         stderr=subprocess.DEVNULL)
+                                          "--protected-mode", "no"], stdout=log,
+                                         stderr=log)
     except FileNotFoundError:
         raise OSError("In order for redis to launch you need both the redis client and the python bindings. "
                       "You seem to be missing the redis client.  Do 'conda install redis' and try again. If "
@@ -208,13 +211,13 @@ def launch_redis(port: int) -> subprocess.Popen:
     return redis_process
 
 
-def launch_redis_processes(num_processes: int) -> Tuple[str, List[Tuple[str, int]]]:
+def launch_redis_processes(num_processes: int, logging_dirs: Dict) -> Tuple[str, List[Tuple[str, int]]]:
     hostname = socket.getfqdn()
     redis_ports = []
     for i in range(num_processes):
         port = get_random_free_port()
         logger.info(f'Starting Redis Broker at {hostname}:{port}')
-        launch_redis(port)
+        launch_redis(port, logging_dirs)
         redis_ports.append((hostname, port))
 
     redis_urls = [f'redis://{hostname}:{port}' for hostname, port in redis_ports]
@@ -447,7 +450,7 @@ def main(model_specification_file: str, branch_configuration_file: str, artifact
     if redis_processes == -1:
         redis_processes = int(math.ceil(len(jobs) / vct_globals.DEFAULT_JOBS_PER_REDIS_INSTANCE))
 
-    worker_template, redis_ports = launch_redis_processes(redis_processes)
+    worker_template, redis_ports = launch_redis_processes(redis_processes, logging_dirs)
     worker_file = output_dir / 'settings.py'
     with worker_file.open('w') as f:
         f.write(worker_template)

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -194,7 +194,7 @@ def get_random_free_port() -> int:
 
 
 def launch_redis(port: int, logging_dirs: Dict) -> subprocess.Popen:
-    log = open(f'{logging_dirs["main"]}/redis.log', 'a')
+    log = open(f'{logging_dirs["main"]}/redis.p{port}.log', 'a')
     log.write(f'>>>>>>>> Starting log for redis-server on port {port}\n')
     log.flush()
     try:


### PR DESCRIPTION
This change add logs for the redis-servers, one per port/process. Example of output is below
```
$ ls -1  # of the log directory
master.log
master.log.json
redis.p38145.log
redis.p42075.log
redis.p45327.log
redis.p47313.log
redis.p57591.log
redis.p57741.log
sge_logs
worker_logs

$ cat redis.p38145.log
>>>>>>>> Starting log for redis-server on port 38145
4000970:C 27 Aug 2021 14:51:11.392 # oO0OoO0OoO0Oo Redis is starting oO0OoO0OoO0Oo
4000970:C 27 Aug 2021 14:51:11.392 # Redis version=5.0.3, bits=64, commit=00000000, modified=0, pid=4000970, just started
4000970:C 27 Aug 2021 14:51:11.392 # Configuration loaded
4000970:M 27 Aug 2021 14:51:11.393 * Running mode=standalone, port=38145.
4000970:M 27 Aug 2021 14:51:11.393 # Server initialized
4000970:M 27 Aug 2021 14:51:11.393 # WARNING overcommit_memory is set to 0! Background save may fail under low memory condition. To fix this issue add 'vm.overcommit_memory = 1' to /etc/sysctl.conf and then reboot or run the command 'sysctl vm.overcommit_memory=1' for this to take effect.
4000970:M 27 Aug 2021 14:51:11.393 # WARNING you have Transparent Huge Pages (THP) support enabled in your kernel. This will create latency and memory usage issues with Redis. To fix this issue run the command 'echo never > /sys/kernel/mm/transparent_hugepage/enabled' as root, and add it to your /etc/rc.local in order to retain the setting after a reboot. Redis must be restarted after THP is disabled.
4000970:M 27 Aug 2021 14:51:11.393 * Ready to accept connections
```

Tested with a `psimulate run` and `restart`. In both cases, logs appeared as expected.