### PR TITLE
Set loglevel to debug for redis-server

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -201,6 +201,8 @@ def launch_redis(port: int, logging_dirs: Dict) -> subprocess.Popen:
         # inline config for redis server.
         redis_process = subprocess.Popen(["redis-server", "--port", f"{port}",
                                           "--timeout", "2",
+                                          "--loglevel", "debug",
+                                         # "--daemonize", "yes",
                                           "--protected-mode", "no"], stdout=log,
                                          stderr=log)
     except FileNotFoundError:


### PR DESCRIPTION
Increases the loglevel for redis-server to debug. This allows for more useful logs.

Tested against several multiple myeloma runs.