### PR TITLE
Separate error handling and results writing

### DIFF
--- a/src/vivarium_cluster_tools/utilities.py
+++ b/src/vivarium_cluster_tools/utilities.py
@@ -6,7 +6,10 @@ vivarium_cluster_tools Utilities
 Making directories is hard.
 
 """
+import functools
 import os
+import time
+import warnings
 from pathlib import Path
 from typing import Union
 
@@ -14,12 +17,19 @@ from typing import Union
 def mkdir(
     path: Union[str, Path], umask: int = 0o002, exists_ok: bool = False, parents: bool = False
 ) -> None:
-    """
-    Utility method to create a directory with specified permissions
-    :param path: path of the directory to create
-    :param umask: umask specifying the desired permissions - defaults to 0o002
-    :param exists_ok: if False, raises FileExistsError if the directory already exists
-    :param parents: if False, raises FileNotFoundError if the directory's parent doesn't exist
+    """Utility method to create a directory with specified permissions.
+
+    Parameters
+    ----------
+    path
+        Path of the directory to create.
+    umask
+        Umask specifying the desired permissions - defaults to 0o002.
+    exists_ok
+        If False, raises FileExistsError if the directory already exists.
+    parents
+        If False, raises FileNotFoundError if the directory's parent doesn't exist.
+
     """
     path = Path(path)
     old_umask = os.umask(umask)
@@ -27,3 +37,44 @@ def mkdir(
         path.mkdir(exist_ok=exists_ok, parents=parents)
     finally:
         os.umask(old_umask)
+
+
+def backoff_and_retry(
+    backoff_seconds: Union[int, float] = 30, num_retries: int = 3, log_function=warnings.warn
+):
+    """Adds a retry handler to the decorated function.
+
+    Parameters
+    ----------
+    backoff_seconds
+        Number of seconds to wait until retrying the operation.
+    num_retries
+        Number of times to retry before failing.
+    log_function
+        A callable used to emit retry messages.  Defaults to emitting
+        a standard library warning.
+
+    """
+
+    def _wrap(func):
+        @functools.wraps(func)
+        def _wrapped(*args, **kwargs):
+            retries = num_retries
+            while retries:
+                try:
+                    result = func(*args, **kwargs)
+                    break
+                except Exception as e:
+                    log_function(
+                        f"Error trying to write results to hdf, retries remaining {retries}"
+                    )
+                    time.sleep(backoff_seconds)
+                    retries -= 1
+                    if not retries:
+                        log_function(f"Retries exhausted.")
+                        raise e
+            return result
+
+        return _wrapped
+
+    return _wrap


### PR DESCRIPTION
## Separate error handling and results writing
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: [MIC-2881](https://jira.ihme.washington.edu/browse/MIC-2881)

Pull error handling out into a decorator, add a test, and use the 
implementation in results writing.

### Testing
CI plus new unit test.
