### PR TITLE
Remove dead args to main

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -24,23 +24,15 @@ class Keyspace:
         self._keyspace = keyspace
 
     @classmethod
-    def from_branch_configuration(
-        cls, num_input_draws, num_random_seeds, branch_configuration_file
-    ):
+    def from_branch_configuration(cls, branch_configuration_file):
         """
         Parameters
         ----------
-        num_input_draws: int
-            The number of GBD input draws to run.
-        num_random_seeds: int
-            The number of different random seeds to use for each GBD input draw.  Each model
-            draw creates a simulation with fixed GBD data, but a different sample of the
-            exogenous randomness used in the simulation.
         branch_configuration_file: str
             Absolute path to the branch configuration file.
         """
-        branches, input_draw_count, random_seed_count = load_branches(
-            num_input_draws, num_random_seeds, branch_configuration_file
+        branches, input_draw_count, random_seed_count = load_branch_configuration(
+            branch_configuration_file
         )
         keyspace = calculate_keyspace(branches)
         keyspace["input_draw"] = calculate_input_draws(input_draw_count)
@@ -188,28 +180,7 @@ def calculate_keyspace(branches):
     return keyspace
 
 
-def load_branches(num_input_draws, num_random_seeds, branch_configuration_file):
-    if (
-        num_input_draws is None
-        and num_random_seeds is None
-        and branch_configuration_file is not None
-    ):
-        input_draw_count, random_seed_count, branches = load_branch_configurations(
-            branch_configuration_file
-        )
-    elif num_input_draws is not None and branch_configuration_file is None:
-        input_draw_count = num_input_draws
-        random_seed_count = num_random_seeds if num_random_seeds is not None else 1
-        branches = [None]
-    else:
-        raise ValueError(
-            "Must supply one of branch_configuration_file or --num_input_draws but not both"
-        )
-
-    return branches, input_draw_count, random_seed_count
-
-
-def load_branch_configurations(path):
+def load_branch_configuration(path):
     with open(path) as f:
         data = yaml.full_load(f)
 
@@ -223,7 +194,7 @@ def load_branch_configurations(path):
     else:
         branches = [None]
 
-    return input_draw_count, random_seed_count, branches
+    return branches, input_draw_count, random_seed_count
 
 
 def expand_branch_templates(templates):

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -40,8 +40,6 @@ class RunContext:
         artifact_path: str,
         output_directory: Path,
         logging_directories: Dict[str, Path],
-        num_input_draws: int,
-        num_random_seeds: int,
         restart: bool,
         expand: Dict[str, int],
         no_batch: bool,
@@ -62,9 +60,7 @@ class RunContext:
         else:
             model_specification = build_model_specification(model_specification_file)
 
-            self.keyspace = Keyspace.from_branch_configuration(
-                num_input_draws, num_random_seeds, branch_configuration_file
-            )
+            self.keyspace = Keyspace.from_branch_configuration(branch_configuration_file)
             if artifact_path:
                 if vct_globals.FULL_ARTIFACT_PATH_KEY in self.keyspace:
                     raise ConfigurationError(
@@ -208,8 +204,6 @@ def main(
     result_directory: str,
     native_specification: dict,
     redis_processes: int,
-    num_input_draws: int = None,
-    num_random_seeds: int = None,
     restart: bool = False,
     expand: Dict[str, int] = None,
     no_batch: bool = False,
@@ -221,7 +215,7 @@ def main(
         model_specification_file,
         result_directory,
         restart,
-        expand=bool(num_input_draws or num_random_seeds),
+        expand=bool(expand),
     )
 
     if not no_cleanup:
@@ -241,8 +235,6 @@ def main(
         artifact_path,
         output_dir,
         logging_dirs,
-        num_input_draws,
-        num_random_seeds,
         restart,
         expand,
         no_batch,


### PR DESCRIPTION
## Remove dead args to main
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-2881](https://jira.ihme.washington.edu/browse/MIC-2881)

`num_input_draws` and `num_random_seeds` used to be CLI args, 
but they were removed from the interface without deleting their usage.

I'm pretty sure `psimulate expand` just didn't work before this fix.


### Testing
CI
