### PR TITLE
Add a worker subpackage

### DIFF
--- a/docs/source/api_reference/psimulate/distributed_worker.rst
+++ b/docs/source/api_reference/psimulate/distributed_worker.rst
@@ -1,1 +1,0 @@
-.. automodule:: vivarium_cluster_tools.psimulate.distributed_worker

--- a/docs/source/api_reference/psimulate/worker/core.rst
+++ b/docs/source/api_reference/psimulate/worker/core.rst
@@ -1,0 +1,1 @@
+.. automodule:: vivarium_cluster_tools.psimulate.worker.core

--- a/docs/source/api_reference/psimulate/worker/index.rst
+++ b/docs/source/api_reference/psimulate/worker/index.rst
@@ -1,0 +1,7 @@
+.. automodule:: vivarium_cluster_tools.psimulate.worker
+
+.. toctree::
+   :maxdepth: 2
+   :glob:
+
+   *

--- a/docs/source/api_reference/psimulate/worker/vivarium_work_horse.rst
+++ b/docs/source/api_reference/psimulate/worker/vivarium_work_horse.rst
@@ -1,0 +1,1 @@
+.. automodule:: vivarium_cluster_tools.psimulate.worker.vivarium_work_horse

--- a/src/vivarium_cluster_tools/psimulate/cluster.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster.py
@@ -175,6 +175,13 @@ def init_job_template(
     worker_log_directory: Path,
     worker_settings_file: Path,
 ):
+    # FIXME: Cyclic import if at top level. This launcher template stuff should
+    #   move to the worker subpackage soon.
+    from vivarium_cluster_tools.psimulate.worker import (
+        RETRY_HANDLER_IMPORT_PATH,
+        WORKER_CLASS_IMPORT_PATH,
+    )
+
     launcher = tempfile.NamedTemporaryFile(
         mode="w",
         dir=".",
@@ -192,8 +199,8 @@ def init_job_template(
     {shutil.which('rq')} worker -c {worker_settings_file.stem} \
         --name ${{{ENV_VARIABLES.JOB_ID.name}}}.${{{ENV_VARIABLES.TASK_ID.name}}} \
         --burst \
-        -w "vivarium_cluster_tools.psimulate.distributed_worker.ResilientWorker" \
-        --exception-handler "vivarium_cluster_tools.psimulate.distributed_worker.retry_handler" vivarium
+        -w "{WORKER_CLASS_IMPORT_PATH}" \
+        --exception-handler "{RETRY_HANDLER_IMPORT_PATH}" vivarium
 
     """
     )

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -25,6 +25,7 @@ from vivarium_cluster_tools.psimulate import (
     redis_dbs,
     results,
 )
+from vivarium_cluster_tools.psimulate.worker import WORK_HORSE_PATHS
 from vivarium_cluster_tools.vipin.perf_report import report_performance
 
 
@@ -200,7 +201,9 @@ def main(
     registry_manager = redis_dbs.RegistryManager(redis_ports, num_jobs_completed)
     # Distribute all the remaining jobs across the job queues
     # in the redis databases.
-    registry_manager.enqueue(job_parameters)
+    registry_manager.enqueue(
+        jobs=job_parameters, workhorse_import_path=WORK_HORSE_PATHS["vivarium"]
+    )
 
     # Cluster specification stuff to be cleaned up.
     native_specification["job_name"] = output_paths.root.parts[-2]

--- a/src/vivarium_cluster_tools/psimulate/worker/__init__.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/__init__.py
@@ -1,10 +1,7 @@
 """
-=================
-psimulate Workers
-=================
-
-Import paths for RQ workers.
-
+====================
+psimulate RQ Workers
+====================
 
 Launching RQ workers is done by specifying Python import paths to worker implementations.
 The actual worker classes and functions are hidden from view here as they should not be
@@ -16,11 +13,11 @@ There are three pieces to an RQ worker.
    `rq.Worker` (this default implementation is fully functional on its own). The worker
    class governs interaction with the Redis DB where the jobs and results are stored,
    the retry behavior on DB connection errors, and the forking behavior when it runs
-   a job, and a number of other things. The `ResilientWorker` defined here primarily
-   makes some small adjustments to the logging and retry behavior and squashes some
-   undesirable forking behavior on clusters that can orphan child processes.
-#. The Retry Handler. The retry handler is a plain python function that determines what
-   happens when an actual job fails due to something other than a Redis DB connection
+   a job, and a number of other things. The `ResilientWorker` defined in the `core` module
+   primarily makes some small adjustments to the logging and retry behavior and squashes
+   some undesirable forking behavior on clusters that can orphan child processes.
+#. The Exception handler. The exception handler is a plain python function that determines
+   what happens when an actual job fails due to something other than a Redis DB connection
    issue. These failures usually occur when there is a code error, a data error, or
    an inability to access some resource within the job itself (filesystem, database, etc.).
 #. The Work Horse.  The work horse is also a plain python function. It is the actual
@@ -31,13 +28,12 @@ There are three pieces to an RQ worker.
    (using pickle, I'm pretty sure) and stored back in the results section of the connected
    Redis DB.
 
+The `build_launch_script` function provided by this package produces a shell file
+used to spin up our (slightly customized) general purpose worker class with an exception
+handler that will retry jobs a couple of times.
 
 """
-# Worker class and retry handler. Can be used for pretty much anything.
-from vivarium_cluster_tools.psimulate.worker.core import (
-    RETRY_HANDLER_IMPORT_PATH,
-    WORKER_CLASS_IMPORT_PATH,
-)
+from vivarium_cluster_tools.psimulate.worker.core import build_launch_script
 
 # Work horses are specific to a kind of job.
 from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import (

--- a/src/vivarium_cluster_tools/psimulate/worker/__init__.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/__init__.py
@@ -1,0 +1,54 @@
+"""
+=================
+psimulate Workers
+=================
+
+Import paths for RQ workers.
+
+
+Launching RQ workers is done by specifying Python import paths to worker implementations.
+The actual worker classes and functions are hidden from view here as they should not be
+referenced directly in the main `psimulate` process.
+
+There are three pieces to an RQ worker.
+
+#. The Worker Class. The worker class and is a normal Python class that inherits from
+   `rq.Worker` (this default implementation is fully functional on its own). The worker
+   class governs interaction with the Redis DB where the jobs and results are stored,
+   the retry behavior on DB connection errors, and the forking behavior when it runs
+   a job, and a number of other things. The `ResilientWorker` defined here primarily
+   makes some small adjustments to the logging and retry behavior and squashes some
+   undesirable forking behavior on clusters that can orphan child processes.
+#. The Retry Handler. The retry handler is a plain python function that determines what
+   happens when an actual job fails due to something other than a Redis DB connection
+   issue. These failures usually occur when there is a code error, a data error, or
+   an inability to access some resource within the job itself (filesystem, database, etc.).
+#. The Work Horse.  The work horse is also a plain python function. It is the actual
+   execution logic of a job (a job is a blob of parameters retrieved by the worker class
+   and passed in to the work horse). The function takes a single argument which is
+   deserialized off the job queue in the connected Redis database. The body of the function
+   can really do anything at that point. It can then return a value which will be serialized
+   (using pickle, I'm pretty sure) and stored back in the results section of the connected
+   Redis DB.
+
+
+"""
+# Worker class and retry handler. Can be used for pretty much anything.
+from vivarium_cluster_tools.psimulate.worker.core import (
+    RETRY_HANDLER_IMPORT_PATH,
+    WORKER_CLASS_IMPORT_PATH,
+)
+
+# Work horses are specific to a kind of job.
+from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import (
+    VIVARIUM_WORK_HORSE_IMPORT_PATH,
+)
+
+# All work horses available to psimulate
+WORK_HORSE_PATHS = {
+    "vivarium": VIVARIUM_WORK_HORSE_IMPORT_PATH,
+    # TODO: Build some test work horses!
+}
+
+# Remove from name space.  All references should be through the WORK_HORSE_PATHS dict.
+del VIVARIUM_WORK_HORSE_IMPORT_PATH

--- a/src/vivarium_cluster_tools/psimulate/worker/core.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/core.py
@@ -1,0 +1,93 @@
+"""
+==================
+Distributed Worker
+==================
+
+RQ worker with custom retry handling.
+
+"""
+import os
+import random
+import time
+from pathlib import Path
+
+import redis
+from loguru import logger
+from rq import Queue
+from rq.job import JobStatus
+from rq.registry import FailedJobRegistry
+from rq.worker import Worker
+
+from vivarium_cluster_tools.psimulate.cluster import ENV_VARIABLES
+
+RETRY_HANDLER_IMPORT_PATH = f"{__name__}.retry_handler"
+WORKER_CLASS_IMPORT_PATH = f"{__name__}.ResilientWorker"
+
+
+def retry_handler(job, *exc_info):
+    retries = job.meta.get("remaining_retries", 2)
+
+    if retries > 0:
+        retries -= 1
+        job.meta["remaining_retries"] = retries
+        job.set_status(JobStatus.QUEUED)
+        job.exc_info = exc_info
+        job.save()
+        q = Queue(name=job.origin, connection=job.connection)
+        q.enqueue_job(job)
+        logger.info(f"Retrying job {job.id}")
+    else:
+        logger.error(f"Failing job {job.id}")
+        q = Queue(name=job.origin, connection=job.connection)
+        failed_queue = FailedJobRegistry(queue=q)
+        failed_queue.add(job, exc_string=exc_info)
+    return False
+
+
+class ResilientWorker(Worker):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.acceptable_failure_count = 3
+
+    def work(self, *args, **kwargs):
+        worker_ = self.name
+        logging_directory = Path(ENV_VARIABLES.VIVARIUM_LOGGING_DIRECTORY.value)
+        logger.add(logging_directory / (str(worker_) + ".log"), level="DEBUG", serialize=True)
+        kwargs["logging_level"] = "DEBUG"
+
+        retries = 0
+        while retries < 10:
+            try:
+                super(ResilientWorker, self).work(*args, **kwargs)
+                return
+            except redis.exceptions.ConnectionError:
+                backoff = random.random() * 60
+                logger.error(f"Couldn't connect to redis. Retrying in {backoff}...")
+                retries += 1
+                time.sleep(backoff)
+        logger.error(f"Ran out of retries. Killing worker")
+
+    def main_work_horse(self, job, queue):
+        retries = 0
+        while retries < 10:
+            try:
+                super(ResilientWorker, self).main_work_horse(job, queue)
+                return
+            except redis.exceptions.ConnectionError:
+                backoff = random.random() * 60
+                logger.error(f"Couldn't connect to redis. Retrying in {backoff}...")
+                retries += 1
+                time.sleep(backoff)
+        logger.error(f"Ran out of retries. Killing work horse")
+
+    def fork_work_horse(self, job, queue):
+        """Spawns a work horse to perform the actual work and passes it a job."""
+        child_pid = os.fork()
+        ENV_VARIABLES.RQ_WORKER_ID.update(self.name)
+        ENV_VARIABLES.RQ_JOB_ID.update(job.id)
+        if child_pid == 0:
+            self.main_work_horse(job, queue)
+            os._exit(0)  # just in case
+        else:
+            self._horse_pid = child_pid
+            self.procline("Forked {0} at {1}".format(child_pid, time.time()))

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -1,109 +1,35 @@
 """
-==================
-Distributed Worker
-==================
+===============
+Vivarium Worker
+===============
 
-Custom RQ worker for running vivarium jobs.
+RQ worker executable for running simulation jobs.
 
 """
 import json
 import math
-import os
-import random
 from pathlib import Path
-from time import sleep, time
+from time import time
 from traceback import format_exc
 
 import pandas as pd
-import redis
 from loguru import logger
-from rq import Queue, get_current_job
-from rq.job import JobStatus
-from rq.registry import FailedJobRegistry
-from rq.worker import Worker
+from rq import get_current_job
 from vivarium.framework.engine import SimulationContext
 from vivarium.framework.utilities import collapse_nested_dict
 
-from vivarium_cluster_tools.psimulate import jobs
 from vivarium_cluster_tools.psimulate.cluster import ENV_VARIABLES
+from vivarium_cluster_tools.psimulate.jobs import JobParameters
 from vivarium_cluster_tools.vipin.perf_counters import CounterSnapshot
 
-
-def retry_handler(job, *exc_info):
-    retries = job.meta.get("remaining_retries", 2)
-
-    if retries > 0:
-        retries -= 1
-        job.meta["remaining_retries"] = retries
-        job.set_status(JobStatus.QUEUED)
-        job.exc_info = exc_info
-        job.save()
-        q = Queue(name=job.origin, connection=job.connection)
-        q.enqueue_job(job)
-        logger.info(f"Retrying job {job.id}")
-    else:
-        logger.error(f"Failing job {job.id}")
-        # exc_string = Worker._get_safe_exception_string(traceback.format_exception(*exc_info))
-        q = Queue(name=job.origin, connection=job.connection)
-        failed_queue = FailedJobRegistry(queue=q)
-        failed_queue.add(job, exc_string=exc_info)
-    return False
+VIVARIUM_WORK_HORSE_IMPORT_PATH = f"{__name__}.worker"
 
 
-class ResilientWorker(Worker):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.acceptable_failure_count = 3
-
-    def work(self, *args, **kwargs):
-        worker_ = self.name
-        logging_directory = Path(ENV_VARIABLES.VIVARIUM_LOGGING_DIRECTORY.value)
-        logger.add(logging_directory / (str(worker_) + ".log"), level="DEBUG", serialize=True)
-        kwargs["logging_level"] = "DEBUG"
-
-        retries = 0
-        while retries < 10:
-            try:
-                super(ResilientWorker, self).work(*args, **kwargs)
-                return
-            except redis.exceptions.ConnectionError:
-                backoff = random.random() * 60
-                logger.error(f"Couldn't connect to redis. Retrying in {backoff}...")
-                retries += 1
-                sleep(backoff)
-        logger.error(f"Ran out of retries. Killing worker")
-
-    def main_work_horse(self, job, queue):
-        retries = 0
-        while retries < 10:
-            try:
-                super(ResilientWorker, self).main_work_horse(job, queue)
-                return
-            except redis.exceptions.ConnectionError:
-                backoff = random.random() * 60
-                logger.error(f"Couldn't connect to redis. Retrying in {backoff}...")
-                retries += 1
-                sleep(backoff)
-        logger.error(f"Ran out of retries. Killing work horse")
-
-    def fork_work_horse(self, job, queue):
-        """Spawns a work horse to perform the actual work and passes it a job."""
-        child_pid = os.fork()
-        ENV_VARIABLES.RQ_WORKER_ID.update(self.name)
-        ENV_VARIABLES.RQ_JOB_ID.update(job.id)
-        if child_pid == 0:
-            self.main_work_horse(job, queue)
-            os._exit(0)  # just in case
-        else:
-            self._horse_pid = child_pid
-            self.procline("Forked {0} at {1}".format(child_pid, time()))
-
-
-def worker(job_parameters: dict):
+def work_horse(job_parameters: dict):
     node = f"{ENV_VARIABLES.CLUSTER_NAME.value}:{ENV_VARIABLES.HOSTNAME.value}"
     job = f"{ENV_VARIABLES.JOB_NAME.value}: {ENV_VARIABLES.JOB_ID.value}:{ENV_VARIABLES.TASK_ID.value}"
 
-    job_parameters = jobs.JobParameters(**job_parameters)
+    job_parameters = JobParameters(**job_parameters)
 
     logger.info(f"Launching new job {job} on {node}")
     logger.info(f"Starting job: {job_parameters}")
@@ -209,7 +135,7 @@ def do_sim_epilogue(
     end: CounterSnapshot,
     event: dict,
     exec_time: dict,
-    parameters: jobs.JobParameters,
+    parameters: JobParameters,
 ):
     exec_time["results_minutes"] = (event["end"] - event["results_start"]) / 60
     logger.info(f'Results reporting completed in {exec_time["results_minutes"]:.3f} minutes.')


### PR DESCRIPTION
## Add a worker subpackage
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: refactor
- *JIRA issue*: [MIC-2881](https://jira.ihme.washington.edu/browse/MIC-2881)

Split the worker side RQ database logic from the worker simulation execution
logic in a worker subpackage and extract the code that produces the worker 
launch script from the drmaa job template initialization. This also sets up the 
structure to parameterize  psimulate with test workloads (see [MIC-2357](https://jira.ihme.washington.edu/browse/MIC-2357)),
which is how I'll do a first round integration test of all this shuffling around.

### Testing
CI

