### PR TITLE
use artifact to generate results directory name

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/paths.py
+++ b/src/vivarium_cluster_tools/psimulate/paths.py
@@ -70,7 +70,7 @@ class OutputPaths(NamedTuple):
         cls,
         *,
         command: str,
-        input_model_specification_path: Optional[Path],
+        input_artifact_path: Optional[Path],
         result_directory: Path,
     ) -> "OutputPaths":
         launch_time = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
@@ -78,7 +78,7 @@ class OutputPaths(NamedTuple):
         output_directory = result_directory
         if command == COMMANDS.run:
             output_directory = (
-                output_directory / input_model_specification_path.stem / launch_time
+                output_directory / input_artifact_path.stem / launch_time
             )
         elif command == COMMANDS.load_test:
             output_directory = output_directory / launch_time

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -121,7 +121,7 @@ def main(
     # Generate programmatic representation of the output directory structure
     output_paths = paths.OutputPaths.from_entry_point_args(
         command=command,
-        input_model_specification_path=input_paths.model_specification,
+        input_artifact_path=input_paths.artifact,
         result_directory=input_paths.result_directory,
     )
     logger.info("Setting up output directory and all subdirectories.")


### PR DESCRIPTION
## Fix Output Directory
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-2969](https://jira.ihme.washington.edu/browse/MIC-2969)

Use the artifact path to determine output directory name rather than the model-spec path.

### Testing
Ran psimulate and saw that the output directory was named as expected
