### PR TITLE
Fix pandas deprecation warning for json_normalize import

### DIFF
--- a/src/vivarium_cluster_tools/vipin/perf_report.py
+++ b/src/vivarium_cluster_tools/vipin/perf_report.py
@@ -15,7 +15,7 @@ import numpy as np
 import pandas as pd
 import requests
 from loguru import logger
-from pandas.io.json import json_normalize
+from pandas import json_normalize
 
 BASE_PERF_INDEX_COLS = ["host", "job_number", "task_number", "draw", "seed"]
 


### PR DESCRIPTION
## Fix json_normalize api change
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: <!-- [MIC-3066](https://jira.ihme.washington.edu/browse/MIC-3066) -->

Pandas has moved json_normalize to the package namespace and
deprecated imports from the internals.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

