### PR TITLE
Add second path for job termination error handling

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -75,7 +75,7 @@ def submit_worker_jobs(
         # FIXME: Hack around issue where drmaa.errors sometimes doesn't
         #        exist.
         except Exception as e:
-            if "already completing or completed" in str(e):
+            if "already completing or completed" in str(e) or "Invalid job id specified" in str(e):
                 # This is the case where all our workers have already shut down
                 # on their own, which isn't actually an error.
                 pass


### PR DESCRIPTION
## Add second path for job termination error handling
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: bugfix
- *JIRA issue*: [MIC-3066](https://jira.ihme.washington.edu/browse/MIC-XYZ)

Slurm throws new errors for terminating jobs that don't exist.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

