### PR TITLE
Add results directory to model specification

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -75,9 +75,7 @@ def submit_worker_jobs(
         # FIXME: Hack around issue where drmaa.errors sometimes doesn't
         #        exist.
         except Exception as e:
-            if "already completing or completed" in str(
-                e
-            ) or "Invalid job id specified" in str(e):
+            if "already completing" in str(e) or "Invalid job" in str(e):
                 # This is the case where all our workers have already shut down
                 # on their own, which isn't actually an error.
                 pass

--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -75,7 +75,9 @@ def submit_worker_jobs(
         # FIXME: Hack around issue where drmaa.errors sometimes doesn't
         #        exist.
         except Exception as e:
-            if "already completing or completed" in str(e) or "Invalid job id specified" in str(e):
+            if "already completing or completed" in str(
+                e
+            ) or "Invalid job id specified" in str(e):
                 # This is the case where all our workers have already shut down
                 # on their own, which isn't actually an error.
                 pass

--- a/src/vivarium_cluster_tools/psimulate/model_specification.py
+++ b/src/vivarium_cluster_tools/psimulate/model_specification.py
@@ -27,6 +27,8 @@ if typing.TYPE_CHECKING:
 INPUT_DATA_KEY = "input_data"
 ARTIFACT_PATH_KEY = "artifact_path"
 FULL_ARTIFACT_PATH_KEY = f"{INPUT_DATA_KEY}.{ARTIFACT_PATH_KEY}"
+OUTPUT_DATA_KEY = "output_data"
+RESULTS_DIRECTORY_KEY = "results_directory"
 
 
 def parse(
@@ -34,6 +36,7 @@ def parse(
     input_model_specification_path: Optional[Path],
     artifact_path: Optional[Path],
     model_specification_path: Path,
+    results_root: Path,
     keyspace: "Keyspace",
 ) -> ConfigTree:
     if command in [COMMANDS.restart, COMMANDS.expand]:
@@ -42,6 +45,9 @@ def parse(
         return build_model_specification()
 
     model_specification = build_model_specification(input_model_specification_path)
+    model_specification.configuration[OUTPUT_DATA_KEY].update(
+        {RESULTS_DIRECTORY_KEY: str(results_root)}, source=__file__
+    )
 
     artifact_path_is_cli_arg = artifact_path is not None
     artifact_path_in_keyspace = FULL_ARTIFACT_PATH_KEY in keyspace

--- a/src/vivarium_cluster_tools/psimulate/model_specification.py
+++ b/src/vivarium_cluster_tools/psimulate/model_specification.py
@@ -45,8 +45,9 @@ def parse(
         return build_model_specification()
 
     model_specification = build_model_specification(input_model_specification_path)
-    model_specification.configuration[OUTPUT_DATA_KEY].update(
-        {RESULTS_DIRECTORY_KEY: str(results_root)}, source=__file__
+    model_specification.configuration.update(
+        {OUTPUT_DATA_KEY: {RESULTS_DIRECTORY_KEY: str(results_root)}},
+        source=__file__,
     )
 
     artifact_path_is_cli_arg = artifact_path is not None

--- a/src/vivarium_cluster_tools/psimulate/paths.py
+++ b/src/vivarium_cluster_tools/psimulate/paths.py
@@ -77,9 +77,7 @@ class OutputPaths(NamedTuple):
 
         output_directory = result_directory
         if command == COMMANDS.run:
-            output_directory = (
-                output_directory / input_artifact_path.stem / launch_time
-            )
+            output_directory = output_directory / input_artifact_path.stem / launch_time
         elif command == COMMANDS.load_test:
             output_directory = output_directory / launch_time
 

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -159,6 +159,7 @@ def main(
         input_model_specification_path=input_paths.model_specification,
         artifact_path=input_paths.artifact,
         model_specification_path=output_paths.model_specification,
+        results_root=output_paths.root,
         keyspace=keyspace,
     )
     model_specification.persist(model_spec, output_paths.model_specification)


### PR DESCRIPTION
## Add results directory to model specification
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
*Category*: feature
*JIRA issue*: [MIC-2997](https://jira.ihme.washington.edu/browse/MIC-2997)

Adds the results directory to the model specification consistent with the
keys defined when doing a single `simulate` run: https://github.com/ihmeuw/vivarium/blob/main/src/vivarium/interface/cli.py#L115-L121
This will allow components to look up where results are being written
and add their own outputs.

### Testing
Running IV iron model
