### PR TITLE
Bugfix/mic 3070 psim restart regression

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/jobs.py
+++ b/src/vivarium_cluster_tools/psimulate/jobs.py
@@ -103,8 +103,8 @@ def already_complete(job_parameters: JobParameters, existing_outputs: pd.DataFra
     job_parameter_list = collapse_nested_dict(job_parameters.branch_configuration)
     job_parameter_list.extend(
         [
-            ("input_draw", job_parameters.input_draw),
-            ("random_seed", job_parameters.random_seed),
+            ("run_configuration.run_key.input_draw", job_parameters.input_draw),
+            ("run_configuration.run_key.random_seed", job_parameters.random_seed),
         ]
     )
 

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -134,8 +134,7 @@ def main(
     # Either write a requirements.txt with the current environment
     # or verify the current environment matches the prior environment
     # used when doing a restart.
-    # XXX DEBUG: reenable later...
-    # pip_env.validate(output_paths.environment_file)
+    pip_env.validate(output_paths.environment_file)
 
     logger.info(
         "Parsing input arguments into model specification and branches and writing to disk."

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -134,7 +134,8 @@ def main(
     # Either write a requirements.txt with the current environment
     # or verify the current environment matches the prior environment
     # used when doing a restart.
-    pip_env.validate(output_paths.environment_file)
+    # XXX DEBUG: reenable later...
+    # pip_env.validate(output_paths.environment_file)
 
     logger.info(
         "Parsing input arguments into model specification and branches and writing to disk."


### PR DESCRIPTION
## Mend key mismatch for random_seed and input_draw columns

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3070](https://jira.ihme.washington.edu/browse/MIC-3070)

Existing code was expecting a different column name for both input_draw and
random seed. This change corrects this.

### Testing
Removed a seed's results from an existing results hdf file and attempted to 
`psimulate restart`, succeeded.
