### PR TITLE
Make draw and seed generation deterministic in parallel simulations

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -138,6 +138,8 @@ def calculate_input_draws(
         min_input_draw_count_allowed = 1
     np.random.shuffle(possible)
     if min_input_draw_count_allowed <= input_draw_count <= len(possible):
+        # XXX
+        breakpoint()
         return possible[:input_draw_count]
     else:
         raise ValueError(
@@ -176,9 +178,9 @@ def calculate_random_seeds(
 
     if existing_seeds:
         possible = list(set(possible).difference(existing_seeds))
+    np.random.shuffle(possible)
     # XXX
     breakpoint()
-    np.random.shuffle(possible)
     return possible[:random_seed_count]
 
 

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -132,12 +132,10 @@ def calculate_input_draws(
     np.random.seed(123456)
     possible = list(range(1000))
     if existing_draws:
-        possible = [list(set(possible).difference(existing_draws))]
+        possible = list(set(possible).difference(existing_draws))
         min_input_draw_count_allowed = 0
     else:
         min_input_draw_count_allowed = 1
-    # XXX
-    breakpoint()
     np.random.shuffle(possible)
     if min_input_draw_count_allowed <= input_draw_count <= len(possible):
         return possible[:input_draw_count]
@@ -177,7 +175,7 @@ def calculate_random_seeds(
     possible = list(range(100000))
 
     if existing_seeds:
-        possible = [list(set(possible).difference(existing_seeds))]
+        possible = list(set(possible).difference(existing_seeds))
     # XXX
     breakpoint()
     np.random.shuffle(possible)

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -129,8 +129,12 @@ def calculate_input_draws(
         existing draw numbers.
 
     """
+    MAX_DRAW_COUNT = 1000
+    if input_draw_count > MAX_DRAW_COUNT:
+        raise ValueError(f"Input draw count must be less than {MAX_DRAW_COUNT}.")
+
     np.random.seed(123456)
-    possible = list(range(1000))
+    possible = list(range(MAX_DRAW_COUNT))
     if existing_draws:
         possible = list(set(possible).difference(existing_draws))
         min_input_draw_count_allowed = 0
@@ -171,8 +175,12 @@ def calculate_random_seeds(
     if not random_seed_count:
         return []
 
+    MAX_SEED_COUNT = 10000
+    if random_seed_count > MAX_SEED_COUNT:
+        raise ValueError(f"Random seed count must be less than {MAX_SEED_COUNT}.")
+
     np.random.seed(654321)
-    possible = list(range(100000))
+    possible = list(range(MAX_SEED_COUNT))
     if existing_seeds:
         possible = list(set(possible).difference(existing_seeds))
     np.random.shuffle(possible)

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -138,8 +138,6 @@ def calculate_input_draws(
         min_input_draw_count_allowed = 1
     np.random.shuffle(possible)
     if min_input_draw_count_allowed <= input_draw_count <= len(possible):
-        # XXX
-        breakpoint()
         return possible[:input_draw_count]
     else:
         raise ValueError(
@@ -175,12 +173,9 @@ def calculate_random_seeds(
 
     np.random.seed(654321)
     possible = list(range(100000))
-
     if existing_seeds:
         possible = list(set(possible).difference(existing_seeds))
     np.random.shuffle(possible)
-    # XXX
-    breakpoint()
     return possible[:random_seed_count]
 
 

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -130,15 +130,17 @@ def calculate_input_draws(
 
     """
     np.random.seed(123456)
+    possible = list(range(1000))
     if existing_draws:
-        possible = list(set(range(1000)).difference(existing_draws))
+        possible = [list(set(possible).difference(existing_draws))]
         min_input_draw_count_allowed = 0
     else:
-        possible = list(range(1000))
         min_input_draw_count_allowed = 1
-
+    # XXX
+    breakpoint()
+    np.random.shuffle(possible)
     if min_input_draw_count_allowed <= input_draw_count <= len(possible):
-        return np.random.choice(possible, input_draw_count, replace=False).tolist()
+        return possible[:input_draw_count]
     else:
         raise ValueError(
             f"Input draw count must be between {min_input_draw_count_allowed} "
@@ -172,16 +174,14 @@ def calculate_random_seeds(
         return []
 
     np.random.seed(654321)
+    possible = list(range(100000))
 
     if existing_seeds:
-        min_possible = max(existing_seeds) + 1
-    else:
-        existing_seeds = []
-        min_possible = 0
-
-    low, high = min_possible, min_possible + 10 * random_seed_count
-    possible = list(range(low, high))
-    return np.random.choice(possible, random_seed_count, replace=False).tolist()
+        possible = [list(set(possible).difference(existing_seeds))]
+    # XXX
+    breakpoint()
+    np.random.shuffle(possible)
+    return possible[:random_seed_count]
 
 
 def calculate_keyspace(branches: List[Dict]) -> Dict:


### PR DESCRIPTION
## Make draw and seed generation deterministic in parallel simulations

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3193](https://jira.ihme.washington.edu/browse/MIC-3193)

#### Changes
- Uses `np.random.shuffle` rather than `np.random.choice` to choose the requested amount of draws and seeds
- Note that this sets the max seed count to 10000. This is presumably reasonable.

### Testing
Ran `psimulate run` and `psimulate expand` with breakpoints to watch draws and seeds be drawn deterministically.

