### PR TITLE
Feature/rq dashboard

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/monitoring.py
+++ b/src/vivarium_cluster_tools/psimulate/monitoring.py
@@ -1,0 +1,29 @@
+"""
+Monitoring Module for Psimulate
+"""
+# this will become a subpackage in the future with added functionality
+
+import atexit
+import subprocess
+from pathlib import Path
+
+from loguru import logger
+
+
+def run_rq_dashboard(redis_urls: list, logging_root: Path) -> None:
+    # Get generic hostname url
+    url = redis_urls[0].split("//")[1]
+    hostname = url.split(":")[0]
+
+    # Set up log file
+    rq_dashboard_log = (logging_root / "rq_dashboard.log").open("a")
+    logger.info("Fetching redis urls and starting RQ-Dashboard")
+    url_flags = " ".join([f"-u {url}" for url in redis_urls])
+    command = "rq-dashboard " + url_flags + " --debug"
+
+    proc = subprocess.Popen(
+        command, shell=True, stdout=rq_dashboard_log, stderr=rq_dashboard_log
+    )
+    rq_dashboard_log.write(f"Dashboard running at http://{hostname}:9181\n")
+    logger.info(f"Dashboard running at http://{hostname}:9181")
+    atexit.register(proc.kill)

--- a/src/vivarium_cluster_tools/psimulate/monitoring.py
+++ b/src/vivarium_cluster_tools/psimulate/monitoring.py
@@ -26,4 +26,7 @@ def run_rq_dashboard(redis_urls: list, logging_root: Path) -> None:
     )
     rq_dashboard_log.write(f"Dashboard running at http://{hostname}:9181\n")
     logger.info(f"Dashboard running at http://{hostname}:9181")
+
+    # Cleanup
     atexit.register(proc.kill)
+    atexit.register(rq_dashboard_log.close)

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -8,18 +8,26 @@ The main process loop for `psimulate` runs.
 """
 import atexit
 import logging
+from pathlib import Path
 import subprocess
 import sys
-from pathlib import Path
 from time import sleep, time
 
 import pandas as pd
 from loguru import logger
 from vivarium_cluster_tools import logs
-from vivarium_cluster_tools.psimulate import (COMMANDS, branches, cluster,
-                                              jobs, model_specification, paths,
-                                              pip_env, redis_dbs, results,
-                                              worker)
+from vivarium_cluster_tools.psimulate import (
+    COMMANDS,
+    branches,
+    cluster,
+    jobs,
+    model_specification,
+    paths,
+    pip_env,
+    redis_dbs,
+    results,
+    worker,
+)
 from vivarium_cluster_tools.vipin.perf_report import report_performance
 
 

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -108,7 +108,7 @@ def try_run_vipin(log_path: Path) -> None:
         logger.warning(f"Performance reporting failed with: {e}")
 
 
-def setup_dashboard(redis_urls: list[str]) -> None:
+def setup_dashboard(redis_urls: list) -> None:
     #todo: make rq-dashboard -u urls happen here with Popen\
     # log url so it is not lost in simulation terminal
     split_urls = " ".join(url for url in redis_urls)

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -109,16 +109,21 @@ def try_run_vipin(log_path: Path) -> None:
         logger.warning(f"Performance reporting failed with: {e}")
 
 
-def setup_dashboard(redis_urls: list, output_directory: Path) -> None:
-    #todo: make rq-dashboard -u urls happen here with Popen\
-    # log url so it is not lost in simulation terminal
+def setup_dashboard(hostname: str, redis_urls: list, output_directory: Path) -> None:
+    #todo: make rq.log capture urls and other info
+
+    # Get generic hostname url
+    url = redis_urls[0].split("//")[1]
+    hostname = url.split(":")[0]
+
     logging.basicConfig(filename=output_directory / "rq.log")
     logger.info("Fetching redis urls and starting RQ-Dashboard")
     split_urls = " -u ".join(url for url in redis_urls)
     command = 'rq-dashboard -u ' + split_urls + " --debug"
+
     logger.info(redis_urls)
     logger.info(f"Initializing RQ-Dashboard with command: {command}")
-    logger.info("Dashboard running at http://0.0.0.0.cluster.ihme.washington.edu:9181")
+    logger.info(f"Dashboard running at http://{hostname}:9181")
     subprocess.Popen(command, shell=True)
 
 

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -118,7 +118,7 @@ def setup_dashboard(redis_urls: list, output_directory: Path) -> None:
     command = 'rq-dashboard -u ' + split_urls + " --debug"
     logger.info(redis_urls)
     logger.info(f"Initializing RQ-Dashboard with command: {command}")
-    lgger.info("Dashboard running at http://0.0.0.0.cluster.ihme.washington.edu:9181")
+    logger.info("Dashboard running at http://0.0.0.0.cluster.ihme.washington.edu:9181")
     subprocess.Popen(command, shell=True)
 
 

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -115,19 +115,16 @@ def run_rq_dashboard(redis_urls: list, output_directory: Path) -> None:
     url = redis_urls[0].split("//")[1]
     hostname = url.split(":")[0]
 
-    # Set up logger
+    # Set up log file
     rq_dashboard_log = (output_directory / "rq.log").open("a")
-
     logger.info("Fetching redis urls and starting RQ-Dashboard")
     split_urls = " -u ".join(url for url in redis_urls)
     command = 'rq-dashboard -u ' + split_urls + " --debug"
 
-    logger.info(redis_urls)
-    logger.info(f"Initializing RQ-Dashboard with command: {command}")
+    rq_dashboard_log.write(f"Dashboard running at http://{hostname}:9181")
     logger.info(f"Dashboard running at http://{hostname}:9181")
     proc = subprocess.Popen(command, shell=True, stdout=rq_dashboard_log, stderr=rq_dashboard_log)
 
-    logger.info("Closing dashboard...")
     atexit.register(proc.kill)
 
 def main(

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -7,6 +7,7 @@ The main process loop for `psimulate` runs.
 
 """
 import atexit
+import logging
 from pathlib import Path
 import subprocess
 from time import sleep, time
@@ -108,12 +109,16 @@ def try_run_vipin(log_path: Path) -> None:
         logger.warning(f"Performance reporting failed with: {e}")
 
 
-def setup_dashboard(redis_urls: list) -> None:
+def setup_dashboard(redis_urls: list, output_directory: Path) -> None:
     #todo: make rq-dashboard -u urls happen here with Popen\
     # log url so it is not lost in simulation terminal
+    logging.basicConfig(filename=output_directory / "rq.log")
     logger.info("Fetching redis urls and starting RQ-Dashboard")
     split_urls = " -u ".join(url for url in redis_urls)
     command = 'rq-dashboard -u ' + split_urls + " --debug"
+    logger.info(redis_urls)
+    logger.info(f"Initializing RQ-Dashboard with command: {command}")
+    lgger.info("Dashboard running at http://0.0.0.0.cluster.ihme.washington.edu:9181")
     subprocess.Popen(command, shell=True)
 
 
@@ -222,7 +227,7 @@ def main(
     # Grab redis urls for dashboard and send them to function for popen
     rq_urls = [f"redis://{hostname}.cluster.ihme.washington.edu:{port}" for hostname, port in redis_ports]
     # todo: add logger and make sure this works
-    setup_dashboard(rq_urls)
+    setup_dashboard(rq_urls, output_paths.logging_root)
 
     worker_template = (
         f"import random\nredis_urls = {redis_urls}\nREDIS_URL = random.choice(redis_urls)\n\n"

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -8,6 +8,7 @@ The main process loop for `psimulate` runs.
 """
 import atexit
 import logging
+import sys
 from pathlib import Path
 import subprocess
 from time import sleep, time
@@ -115,16 +116,16 @@ def run_rq_dashboard(redis_urls: list, output_directory: Path) -> None:
     hostname = url.split(":")[0]
 
     # Set up logger
-    logging.basicConfig(filename=output_directory / "rq.log")
+    rq_dashboard_log = (output_directory / "rq.log").open("a")
 
     logger.info("Fetching redis urls and starting RQ-Dashboard")
     split_urls = " -u ".join(url for url in redis_urls)
     command = 'rq-dashboard -u ' + split_urls + " --debug"
 
-    rq_logger.info(redis_urls)
+    logger.info(redis_urls)
     logger.info(f"Initializing RQ-Dashboard with command: {command}")
     logger.info(f"Dashboard running at http://{hostname}:9181")
-    proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    proc = subprocess.Popen(command, shell=True, stdout=rq_dashboard_log, stderr=rq_dashboard_log)
 
     logger.info("Closing dashboard...")
     atexit.register(proc.kill)

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -114,16 +114,19 @@ def run_rq_dashboard(redis_urls: list, output_directory: Path) -> None:
     url = redis_urls[0].split("//")[1]
     hostname = url.split(":")[0]
 
+    # Set up logger
     logging.basicConfig(filename=output_directory / "rq.log")
+
     logger.info("Fetching redis urls and starting RQ-Dashboard")
     split_urls = " -u ".join(url for url in redis_urls)
     command = 'rq-dashboard -u ' + split_urls + " --debug"
 
-    logger.info(redis_urls)
+    rq_logger.info(redis_urls)
     logger.info(f"Initializing RQ-Dashboard with command: {command}")
     logger.info(f"Dashboard running at http://{hostname}:9181")
-
     proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+
+    logger.info("Closing dashboard...")
     atexit.register(proc.kill)
 
 def main(

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -8,27 +8,18 @@ The main process loop for `psimulate` runs.
 """
 import atexit
 import logging
+import subprocess
 import sys
 from pathlib import Path
-import subprocess
 from time import sleep, time
 
 import pandas as pd
 from loguru import logger
-
 from vivarium_cluster_tools import logs
-from vivarium_cluster_tools.psimulate import (
-    COMMANDS,
-    branches,
-    cluster,
-    jobs,
-    model_specification,
-    paths,
-    pip_env,
-    redis_dbs,
-    results,
-    worker,
-)
+from vivarium_cluster_tools.psimulate import (COMMANDS, branches, cluster,
+                                              jobs, model_specification, paths,
+                                              pip_env, redis_dbs, results,
+                                              worker)
 from vivarium_cluster_tools.vipin.perf_report import report_performance
 
 

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -113,7 +113,7 @@ def setup_dashboard(redis_urls: list) -> None:
     # log url so it is not lost in simulation terminal
     logger.info("Fetching redis urls and starting RQ-Dashboard")
     split_urls = " -u ".join(url for url in redis_urls)
-    command = 'rq-dashboard -u ' + split_urls
+    command = 'rq-dashboard -u ' + split_urls + " --debug"
     subprocess.Popen(command, shell=True)
 
 

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -7,9 +7,7 @@ The main process loop for `psimulate` runs.
 
 """
 import atexit
-import logging
 import subprocess
-import sys
 from pathlib import Path
 from time import sleep, time
 

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -111,9 +111,10 @@ def try_run_vipin(log_path: Path) -> None:
 def setup_dashboard(redis_urls: list) -> None:
     #todo: make rq-dashboard -u urls happen here with Popen\
     # log url so it is not lost in simulation terminal
-    split_urls = " ".join(url for url in redis_urls)
+    logger.info("Fetching redis urls and starting RQ-Dashboard")
+    split_urls = " -u ".join(url for url in redis_urls)
     command = 'rq-dashboard -u ' + split_urls
-    subprocess.run(command, shell=True)
+    subprocess.Popen(command, shell=True)
 
 
 def main(

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -124,7 +124,7 @@ def run_rq_dashboard(redis_urls: list, output_directory: Path) -> None:
     logger.info(f"Dashboard running at http://{hostname}:9181")
 
     proc = subprocess.Popen(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
-    atexit.register(proc.kill())
+    atexit.register(proc.kill)
 
 def main(
     command: str,

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -13,6 +13,7 @@ from time import sleep, time
 
 import pandas as pd
 from loguru import logger
+
 from vivarium_cluster_tools import logs
 from vivarium_cluster_tools.psimulate import (
     COMMANDS,

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -8,9 +8,9 @@ The main process loop for `psimulate` runs.
 """
 import atexit
 import logging
-from pathlib import Path
 import subprocess
 import sys
+from pathlib import Path
 from time import sleep, time
 
 import pandas as pd
@@ -114,7 +114,7 @@ def run_rq_dashboard(redis_urls: list, output_directory: Path) -> None:
     split_urls = " -u ".join(url for url in redis_urls)
     command = "rq-dashboard -u " + split_urls + " --debug"
 
-    rq_dashboard_log.write(f"Dashboard running at http://{hostname}:9181")
+    rq_dashboard_log.write(f"Dashboard running at http://{hostname}:9181\n")
     logger.info(f"Dashboard running at http://{hostname}:9181")
     proc = subprocess.Popen(
         command, shell=True, stdout=rq_dashboard_log, stderr=rq_dashboard_log

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -51,10 +51,7 @@ def process_job_results(
 
             if len(unwritten_results) > batch_size:
                 written_results, unwritten_results = results.write_results_batch(
-                    output_directory,
-                    written_results,
-                    unwritten_results,
-                    batch_size,
+                    output_directory, written_results, unwritten_results, batch_size
                 )
 
             registry_manager.update_and_report()
@@ -64,10 +61,7 @@ def process_job_results(
         batch_size = 500
         while unwritten_results:
             written_results, unwritten_results = results.write_results_batch(
-                output_directory,
-                written_results,
-                unwritten_results,
-                batch_size=batch_size,
+                output_directory, written_results, unwritten_results, batch_size=batch_size
             )
             logger.info(f"Unwritten results: {len(unwritten_results)}")
             logger.info(f"Elapsed time: {(time() - start_time) / 60:.1f} minutes.")
@@ -119,13 +113,16 @@ def run_rq_dashboard(redis_urls: list, output_directory: Path) -> None:
     rq_dashboard_log = (output_directory / "rq.log").open("a")
     logger.info("Fetching redis urls and starting RQ-Dashboard")
     split_urls = " -u ".join(url for url in redis_urls)
-    command = 'rq-dashboard -u ' + split_urls + " --debug"
+    command = "rq-dashboard -u " + split_urls + " --debug"
 
     rq_dashboard_log.write(f"Dashboard running at http://{hostname}:9181")
     logger.info(f"Dashboard running at http://{hostname}:9181")
-    proc = subprocess.Popen(command, shell=True, stdout=rq_dashboard_log, stderr=rq_dashboard_log)
+    proc = subprocess.Popen(
+        command, shell=True, stdout=rq_dashboard_log, stderr=rq_dashboard_log
+    )
 
     atexit.register(proc.kill)
+
 
 def main(
     command: str,
@@ -230,7 +227,10 @@ def main(
     redis_urls = [f"redis://{hostname}:{port}" for hostname, port in redis_ports]
 
     # Grab redis urls for dashboard and send them to function for popen
-    rq_urls = [f"redis://{hostname}.cluster.ihme.washington.edu:{port}" for hostname, port in redis_ports]
+    rq_urls = [
+        f"redis://{hostname}.cluster.ihme.washington.edu:{port}"
+        for hostname, port in redis_ports
+    ]
     # todo: add logger and make sure this works
     run_rq_dashboard(rq_urls, output_paths.logging_root)
 

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -109,7 +109,7 @@ def try_run_vipin(log_path: Path) -> None:
         logger.warning(f"Performance reporting failed with: {e}")
 
 
-def setup_dashboard(hostname: str, redis_urls: list, output_directory: Path) -> None:
+def setup_dashboard(redis_urls: list, output_directory: Path) -> None:
     #todo: make rq.log capture urls and other info
 
     # Get generic hostname url


### PR DESCRIPTION
## Feature/RQ-Dashboard

### Description
Added functionality to run a RQ-dashboard when user launches a parallel simulation.
- *Category*: Feature
- *JIRA issue*: [MIC-2934](https://jira.ihme.washington.edu/browse/MIC-2934)

-Added run_rq_dashboard function that launches dashboard during main psimulate runner loop
-Dashboard captures all jobs submitted on that host for all redis databases that were provide when dashboard was initialized (current implementation is all redis databases but this could be changed with little work).
-Hook to kill subprocess running dashboard when the parallel simulation ends.
-Added rq.log to log subprocess and provide user with URL to navigate to use the dashboard.  URL is also printed to terminal.

### Testing
Ran multiple parallel simulation and successfully saw working implementation for:
    -Creation and usage of new rq.log file
    -Dashboard launches at start of simulation and the process ends when the simulation finishes
    -All redis databases used for parallel simulation are attached to the dashboard depending on how many were used for that simulation.

