### PR TITLE
 Enable `psimulate` to run without artifact

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/model_specification.py
+++ b/src/vivarium_cluster_tools/psimulate/model_specification.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
+from loguru import logger
+from vivarium.config_tree import ConfigurationKeyError
 from vivarium.framework.artifact import parse_artifact_path_config
 from vivarium.framework.configuration import (
     ConfigTree,
@@ -64,10 +66,15 @@ def parse(
             {ARTIFACT_PATH_KEY: str(artifact_path)}, source=__file__
         )
     else:
-        # Artifact path comes from the model spec.
-        # Parsing here ensures the key exists and the value points
-        # to an actual file.
-        parse_artifact_path_config(model_specification.configuration)
+        # Artifact path (if any) comes from the model spec.
+        # The framework does not require an artifact, log a debug message in case this
+        # is unintentional...
+        try:
+            parse_artifact_path_config(model_specification.configuration)
+        except ConfigurationKeyError:
+            logger.debug("No artifact detected in arguments or configuration. This may"
+                         " be intentional. If not, supply one with the `-i` flag or in"
+                         " the configuration yaml.")
 
     return model_specification
 

--- a/src/vivarium_cluster_tools/psimulate/paths.py
+++ b/src/vivarium_cluster_tools/psimulate/paths.py
@@ -91,7 +91,7 @@ class OutputPaths(NamedTuple):
                 with open(input_model_spec_path) as model_spec_file:
                     model_spec = yaml.safe_load(model_spec_file)
                 try:
-                    location = model_spec["configuration"]["input_data"]["artifact_path"].stem
+                    location = Path(model_spec["configuration"]["input_data"]["artifact_path"]).stem
                 except KeyError:
                     location = input_model_spec_path.stem
             output_directory = output_directory / location / launch_time

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -6,7 +6,6 @@ psimulate Runner
 The main process loop for `psimulate` runs.
 
 """
-import atexit
 from pathlib import Path
 from time import sleep, time
 
@@ -121,8 +120,9 @@ def main(
     # Generate programmatic representation of the output directory structure
     output_paths = paths.OutputPaths.from_entry_point_args(
         command=command,
-        input_artifact_path=input_paths.artifact,
         result_directory=input_paths.result_directory,
+        input_artifact_path=input_paths.artifact,
+        input_model_spec_path=input_paths.model_specification,
     )
     logger.info("Setting up output directory and all subdirectories.")
     output_paths.touch()


### PR DESCRIPTION
## Enable `psimulate` to run without artifact

### Description
- *Category*: bugfix
- *JIRA issue*:  [MIC-3229](https://jira.ihme.washington.edu/browse/MIC-3229) and [MIC-3091](https://jira.ihme.washington.edu/browse/MIC-3091)

Changes:
- Allow `psimulate` to run without an artifact.
- If no artifact is provided, use the model spec yaml's stem to be the stand-in for location in results path.

### Testing
Ran this VCT against IV Iron with an artifact provided only in the YAML and only at the command and @aflaxman's WA DOH staffing repo, which does not have an artifact and motivated one of these JIRA tickets. In each case, the correct artifact (if any) and results path location were as expected (`"south_asia"` in the former case and `"staffing"` in the latter, from `staffing.yaml`

