### PR TITLE
Infer location from artifact, if possible, otherwise use model spec

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/model_specification.py
+++ b/src/vivarium_cluster_tools/psimulate/model_specification.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from typing import Optional
 
 import yaml
+from loguru import logger
+from vivarium.config_tree import ConfigurationKeyError
 from vivarium.framework.artifact import parse_artifact_path_config
 from vivarium.framework.configuration import (
     ConfigTree,
@@ -64,10 +66,15 @@ def parse(
             {ARTIFACT_PATH_KEY: str(artifact_path)}, source=__file__
         )
     else:
-        # Artifact path comes from the model spec.
-        # Parsing here ensures the key exists and the value points
-        # to an actual file.
-        parse_artifact_path_config(model_specification.configuration)
+        # Artifact path (if any) comes from the model spec.
+        # The framework does not require an artifact, log a debug message in case this
+        # is unintentional...
+        try:
+            parse_artifact_path_config(model_specification.configuration)
+        except ConfigurationKeyError:
+            logger.debug("No artifact detected in arguments or configuration. This may"
+                         " be intentional. If not, supply one with the `-i` flag or in"
+                         " the configuration yaml.")
 
     return model_specification
 

--- a/src/vivarium_cluster_tools/psimulate/paths.py
+++ b/src/vivarium_cluster_tools/psimulate/paths.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import NamedTuple, Optional, Union
 
+from vivarium.interface.utilities import get_output_location_like_string
 from vivarium_cluster_tools import utilities as vct_utils
 from vivarium_cluster_tools.psimulate import COMMANDS
 
@@ -72,12 +73,14 @@ class OutputPaths(NamedTuple):
         command: str,
         input_artifact_path: Optional[Path],
         result_directory: Path,
+        input_model_spec_path: Path,
     ) -> "OutputPaths":
         launch_time = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
 
         output_directory = result_directory
         if command == COMMANDS.run:
-            output_directory = output_directory / input_artifact_path.stem / launch_time
+            location = get_output_location_like_string(input_artifact_path, input_model_spec_path)
+            output_directory = output_directory / location / launch_time
         elif command == COMMANDS.load_test:
             output_directory = output_directory / launch_time
 

--- a/src/vivarium_cluster_tools/psimulate/paths.py
+++ b/src/vivarium_cluster_tools/psimulate/paths.py
@@ -8,7 +8,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import NamedTuple, Optional, Union
 
-from vivarium.interface.utilities import get_output_location_like_string
+from vivarium.interface.utilities import get_output_model_name_string
 from vivarium_cluster_tools import utilities as vct_utils
 from vivarium_cluster_tools.psimulate import COMMANDS
 
@@ -79,8 +79,8 @@ class OutputPaths(NamedTuple):
 
         output_directory = result_directory
         if command == COMMANDS.run:
-            location = get_output_location_like_string(input_artifact_path, input_model_spec_path)
-            output_directory = output_directory / location / launch_time
+            model_name = get_output_model_name_string(input_artifact_path, input_model_spec_path)
+            output_directory = output_directory / model_name / launch_time
         elif command == COMMANDS.load_test:
             output_directory = output_directory / launch_time
 

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -123,6 +123,7 @@ def main(
         command=command,
         input_artifact_path=input_paths.artifact,
         result_directory=input_paths.result_directory,
+        input_model_spec_path=input_paths.model_specification,
     )
     logger.info("Setting up output directory and all subdirectories.")
     output_paths.touch()


### PR DESCRIPTION
## Infer location from artifact, if possible, otherwise use model spec

### Description
- *Category*: feature
- *JIRA issue*:  [MIC-3229](https://jira.ihme.washington.edu/browse/MIC-3229) and [MIC-3091](https://jira.ihme.washington.edu/browse/MIC-3091)

Changes:
- Allow `psimulate` to run without an artifact.
- If no artifact is provided, use the model spec yaml's stem to be the stand-in for location in results path.
- If no artifact is provided, emit a debug message asking "are you sure?"
- This change relies on a change in `vivarium` to include `get_output_model_name_string()` (https://github.com/ihmeuw/vivarium/pull/220) 

### Testing
Ran this VCT and Vivarium against IV Iron with an artifact provided only in the YAML and only at the command and @aflaxman's WA DOH staffing repo, which does not have an artifact and motivated one of these JIRA tickets. In each case, the correct artifact (if any) and results path location were as expected (`"south_asia"` in the former case and `"staffing"` in the latter, from `staffing.yaml`
