### PR TITLE
Remove extraneous scenario columns from summary log and report

### DIFF
--- a/src/vivarium_cluster_tools/vipin/perf_report.py
+++ b/src/vivarium_cluster_tools/vipin/perf_report.py
@@ -22,6 +22,17 @@ BASE_PERF_INDEX_COLS = ["host", "job_number", "task_number", "draw", "seed"]
 # The number of scenario columns beyond which we shorten the scenarios to a single string
 COMPOUND_SCENARIO_COL_COUNT = 2
 
+# Scenario columns that are not useful describe a scenario or are duplicated
+EXTRANEOUS_SCENARIO_COLS = [
+    "scenario_run_configuration_run_id",
+    "scenario_run_configuration_results_directory",
+    "scenario_run_configuration_run_key_input_draw",
+    "scenario_run_configuration_run_key_random_seed",
+    "scenario_randomness_random_seed",
+    "scenario_randomness_additional_seed",
+    "scenario_input_data_input_draw_number",
+]
+
 
 class PerformanceSummary:
     """
@@ -85,8 +96,10 @@ class PerformanceSummary:
 
 
 def set_index_scenario_cols(perf_df: pd.DataFrame) -> Tuple[pd.DataFrame, list]:
-    """Given a dataframe from PerformanceSummary.to_df, add QPID Job API data for the job"""
+    """Get the columns useful to index performance data by."""
     index_cols = BASE_PERF_INDEX_COLS
+    # TODO: should we drop these columns? They are extraneous, but maybe useful...
+    # perf_df = perf_df.drop(EXTRANEOUS_SCENARIO_COLS, axis=1)
     scenario_cols = [col for col in perf_df.columns if col.startswith("scenario_")]
     index_cols.extend(scenario_cols)
     perf_df = perf_df.set_index(index_cols)
@@ -118,12 +131,11 @@ def add_jobapi_data(perf_df: pd.DataFrame):
 
 def print_stat_report(perf_df: pd.DataFrame, scenario_cols: list):
     """Print some helpful stats from the performance data, grouped by scenario_cols"""
-    # XXXX
-    breakpoint()
     pd.set_option("display.max_rows", None)
     pd.set_option("display.max_columns", None)
     pd.options.display.float_format = "{:.2f}".format
 
+    scenario_cols = [col for col in scenario_cols if col not in EXTRANEOUS_SCENARIO_COLS]
     do_compound = len(scenario_cols) > COMPOUND_SCENARIO_COL_COUNT
 
     perf_df = perf_df.reset_index()
@@ -184,7 +196,6 @@ def report_performance(
     perf_summary = PerformanceSummary(input_directory)
 
     perf_df = perf_summary.to_df()
-
     if len(perf_df) < 1:
         logger.warning(f"No performance data found in {input_directory}.")
         return  # nothing left to do

--- a/src/vivarium_cluster_tools/vipin/perf_report.py
+++ b/src/vivarium_cluster_tools/vipin/perf_report.py
@@ -98,8 +98,7 @@ class PerformanceSummary:
 def set_index_scenario_cols(perf_df: pd.DataFrame) -> Tuple[pd.DataFrame, list]:
     """Get the columns useful to index performance data by."""
     index_cols = BASE_PERF_INDEX_COLS
-    # TODO: should we drop these columns? They are extraneous, but maybe useful...
-    # perf_df = perf_df.drop(EXTRANEOUS_SCENARIO_COLS, axis=1)
+    perf_df = perf_df.drop(EXTRANEOUS_SCENARIO_COLS, axis=1)
     scenario_cols = [col for col in perf_df.columns if col.startswith("scenario_")]
     index_cols.extend(scenario_cols)
     perf_df = perf_df.set_index(index_cols)
@@ -135,7 +134,6 @@ def print_stat_report(perf_df: pd.DataFrame, scenario_cols: list):
     pd.set_option("display.max_columns", None)
     pd.options.display.float_format = "{:.2f}".format
 
-    scenario_cols = [col for col in scenario_cols if col not in EXTRANEOUS_SCENARIO_COLS]
     do_compound = len(scenario_cols) > COMPOUND_SCENARIO_COL_COUNT
 
     perf_df = perf_df.reset_index()

--- a/src/vivarium_cluster_tools/vipin/perf_report.py
+++ b/src/vivarium_cluster_tools/vipin/perf_report.py
@@ -118,6 +118,8 @@ def add_jobapi_data(perf_df: pd.DataFrame):
 
 def print_stat_report(perf_df: pd.DataFrame, scenario_cols: list):
     """Print some helpful stats from the performance data, grouped by scenario_cols"""
+    # XXXX
+    breakpoint()
     pd.set_option("display.max_rows", None)
     pd.set_option("display.max_columns", None)
     pd.options.display.float_format = "{:.2f}".format


### PR DESCRIPTION
## Remove extraneous scenario columns from summary log and report

### Description
- *Category*:  bugfix
- *JIRA issue*: [MIC-3244](https://jira.ihme.washington.edu/browse/MIC-3244) 

#### Changes
- Pre-Slurm, all the columns prefixed with `scenario_` were meaningful to the scenario and only the scenario. This messed with the reporting at the end of `psimulate -v` which was meant to quickly show any performance differences between the scenarios under simulation. These extraneous columns are now dropped from the performance summary log and the end report.

### Testing
End report looks as expected. The below is for `vivarium_wadoh_staffing` and has 0 time in normal timesteps, which is correct to the model, but weird. 
```
2022-08-18 17:58:24.024 | vivarium_cluster_tools.vipin.perf_report:print_stat_report:142 - compound scenario:
(population_min_bad_outcome_rate/population_pr_zero_bad/run_configuration_run_key_population_min_bad_outcome_rate/run_configuration_run_key_population_pr_zero_bad):
2022-08-18 17:58:24.073 | vivarium_cluster_tools.vipin.perf_report:print_stat_report:183 -
                                         mean  std  min  max
compound_scenario         measure
0.0005/0.001/0.0005/0.001 main_loop_min  0.00 0.00 0.00 0.00
                          results_min    2.85 0.85 2.06 3.75
                          setup_min      0.00 0.00 0.00 0.00
                          sim_init_min   0.00 0.00 0.00 0.00
                          step_mean_s    0.00 0.00 0.00 0.00
                          total_min      2.85 0.85 2.06 3.75
0.005/0.001/0.005/0.001   main_loop_min  0.00 0.00 0.00 0.00
                          results_min    2.62 1.15 1.43 3.72
                          setup_min      0.00 0.00 0.00 0.00
                          sim_init_min   0.00 0.00 0.00 0.00
                          step_mean_s    0.00 0.00 0.00 0.00
                          total_min      2.62 1.15 1.43 3.72
0.05/0.001/0.05/0.001     main_loop_min  0.00 0.00 0.00 0.00
                          results_min    3.13 1.07 2.38 4.35
                          setup_min      0.00 0.00 0.00 0.00
                          sim_init_min   0.00 0.00 0.00 0.00
                          step_mean_s    0.00 0.00 0.00 0.00
                          total_min      3.13 1.07 2.38 4.35
```
Running a truncated maternal IV Iron simulation with a single scenario (baseline), looks as expected. 
```
2022-08-19 10:19:03.819 | vivarium_cluster_tools.vipin.perf_report:print_stat_report:183 -
                                                                                     mean  \
scenario_intervention scenario_run_configuration_run_key_intervention measure
baseline              baseline                                        main_loop_min  1.26
                                                                      results_min    0.00
                                                                      setup_min      0.16
                                                                      sim_init_min   0.07
                                                                      step_mean_s    1.43
                                                                      total_min      1.50

                                                                                     std  \
scenario_intervention scenario_run_configuration_run_key_intervention measure
baseline              baseline                                        main_loop_min 0.38
                                                                      results_min   0.00
                                                                      setup_min     0.03
                                                                      sim_init_min  0.02
                                                                      step_mean_s   0.43
                                                                      total_min     0.42

                                                                                     min  \
scenario_intervention scenario_run_configuration_run_key_intervention measure
baseline              baseline                                        main_loop_min 1.00
                                                                      results_min   0.00
                                                                      setup_min     0.14
                                                                      sim_init_min  0.06
                                                                      step_mean_s   1.13
                                                                      total_min     1.20

                                                                                     max
scenario_intervention scenario_run_configuration_run_key_intervention measure
baseline              baseline                                        main_loop_min 1.53
                                                                      results_min   0.00
                                                                      setup_min     0.18
                                                                      sim_init_min  0.09
                                                                      step_mean_s   1.73
                                                                      total_min     1.80
```