### PR TITLE
Switch from Job API to Squid API

### DIFF
--- a/src/vivarium_cluster_tools/vipin/perf_report.py
+++ b/src/vivarium_cluster_tools/vipin/perf_report.py
@@ -112,7 +112,6 @@ def add_squid_api_data(perf_df: pd.DataFrame):
     try:
         job_numbers = perf_df["job_number"].unique()
         assert len(job_numbers) == 1
-        print(job_numbers)
         squid_api_data = requests.get(
             f"http://squid.ihme.washington.edu/api/jobs?job_ids={job_numbers[0]}"
         ).json()


### PR DESCRIPTION
## Switch from Job API to Squid API

### Description
- *Category*:  bugfixy feature
- *JIRA issue*: [MIC-2823](https://jira.ihme.washington.edu/browse/MIC-2823)

#### Changes
- Ports Job API usage, broken since the move to Slurm, to Squid, which provides similar information.
- Columns in the performance summary log (`worker_logs/log_summary.csv`) taken from Squid API are prefixed `squid_api_`

### Testing
Ran against a very truncated maternal IV iron, csv log created at `worker_logs/log_summary.csv` with expected columns and data.
