### PR TITLE
Add large results load test

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -26,6 +26,9 @@ from vivarium_cluster_tools.psimulate import (
     results,
     runner,
 )
+from vivarium_cluster_tools.psimulate.worker.load_test_work_horse import (
+    get_psimulate_test_dict,
+)
 
 
 @click.group()
@@ -221,7 +224,7 @@ def expand(results_root, **options):
 @psimulate.command()
 @click.argument(
     "test-type",
-    type=click.Choice(["sleep"]),
+    type=click.Choice(list(get_psimulate_test_dict())),
 )
 @click.option(
     "--num-workers",

--- a/src/vivarium_cluster_tools/psimulate/cluster/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/cli_options.py
@@ -17,10 +17,11 @@ with_project = click.option(
     type=click.Choice(
         [
             "proj_simscience",
+            "proj_simscience_prod",
             "proj_csu",
         ]
     ),
-    default="proj_simscience",
+    default="proj_simscience_prod",
     help="The cluster project under which to run the simulation.",
 )
 

--- a/src/vivarium_cluster_tools/psimulate/worker/load_test_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/load_test_work_horse.py
@@ -44,6 +44,7 @@ def sleep_test(job_parameters: JobParameters) -> pd.DataFrame:
 
 def large_results_test(job_parameters: JobParameters) -> pd.DataFrame:
     time.sleep(30)
+    np.random.seed(seed=get_hash(f"large_results_test_{job_parameters.random_seed}"))
     return pd.DataFrame(
         np.random.random(10_000_000).reshape((1_000_000, 10))
     )

--- a/src/vivarium_cluster_tools/psimulate/worker/load_test_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/load_test_work_horse.py
@@ -21,29 +21,11 @@ from vivarium_cluster_tools.psimulate.jobs import JobParameters
 LOAD_TEST_WORK_HORSE_IMPORT_PATH = f"{__name__}.work_horse"
 
 
-def work_horse(job_parameters: dict) -> pd.DataFrame:
-    node = f"{ENV_VARIABLES.HOSTNAME.value}"
-    job = f"{ENV_VARIABLES.JOB_ID.value}:{ENV_VARIABLES.TASK_ID.value}"
-
-    job_parameters = JobParameters(**job_parameters)
-
-    test_type = job_parameters.extras["test_type"]
-    test_runner = {
+def get_psimulate_test_dict():
+    return {
         "sleep": sleep_test,
-    }[test_type]
-
-    logger.info(f"Launching new job {job} on {node}")
-    logger.info(f"Starting job: {job_parameters}")
-    try:
-        return test_runner(job_parameters)
-    except Exception:
-        logger.exception("Unhandled exception in worker")
-        job = get_current_job()
-        job.meta["root_exception"] = format_exc()
-        job.save_meta()
-        raise
-    finally:
-        logger.info(f"Exiting job: {job_parameters}")
+        "large_results": large_results_test
+    }
 
 
 def sleep_test(job_parameters: JobParameters) -> pd.DataFrame:
@@ -58,3 +40,33 @@ def sleep_test(job_parameters: JobParameters) -> pd.DataFrame:
     return pd.DataFrame(
         {"sleep_time": sleep_time}, index=pd.Index([job_parameters.random_seed], name="seed")
     )
+
+
+def large_results_test(job_parameters: JobParameters) -> pd.DataFrame:
+    time.sleep(30)
+    return pd.DataFrame(
+        np.random.random(10_000_000).reshape((1_000_000, 10))
+    )
+
+
+def work_horse(job_parameters: dict) -> pd.DataFrame:
+    node = f"{ENV_VARIABLES.HOSTNAME.value}"
+    job = f"{ENV_VARIABLES.JOB_ID.value}:{ENV_VARIABLES.TASK_ID.value}"
+
+    job_parameters = JobParameters(**job_parameters)
+
+    test_type = job_parameters.extras["test_type"]
+    test_runner = get_psimulate_test_dict()[test_type]
+
+    logger.info(f"Launching new job {job} on {node}")
+    logger.info(f"Starting job: {job_parameters}")
+    try:
+        return test_runner(job_parameters)
+    except Exception:
+        logger.exception("Unhandled exception in worker")
+        job = get_current_job()
+        job.meta["root_exception"] = format_exc()
+        job.save_meta()
+        raise
+    finally:
+        logger.info(f"Exiting job: {job_parameters}")


### PR DESCRIPTION
## Add large results test

### Description
- *Category*: test
- *JIRA issue*: [MIC-3514](https://jira.ihme.washington.edu/browse/MIC-3514)

#### Changes
- Adds a test `psimulate test large_test` to reproduce network connection issues at scale with the current Redis setup in vivarium_cluster_tools
- This test sleeps for 30 seconds, then makes a big random dataframe and returns it.
- Sets the default project to `proj_simscience_prod`.

### Testing
On an srun with 1024 GB of RAM, test completes with 1000 workers (the default) within about 20 minutes.

With 6000+ workers, however I am able to reproduce ConnectionErrors failures seen in previous production runs of large models.
```
psimulate test -vvvvr 00:30:00 -n 6000 -P proj_simscience_prod -o /ihme/scratch/users/username large_results```
```

```
cluster_logs username$ grep redis.exceptions.ConnectionError *.log | wc -l
1363
cluster_logs username$ ls -1 | wc -l
6000
```
