### PR TITLE
update ci and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners
-* @albrja @beatrixkh @collijk @hussain-jafari @mattkappel @ramittal @rmudambi @stevebachmeier
+* @albrja @collijk @hussain-jafari @mattkappel @ramittal @rmudambi @stevebachmeier

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 # -----------------------------------------------------------------------------
 #   - invoked on push, pull_request, or manual trigger
-#   - test under 3 versions of python
+#   - test under at least 3 versions of python
 #   - look for an upstream (vivarium) branch and use it if it exists
 # -----------------------------------------------------------------------------
 name: build
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
     defaults:
       run:
-        shell: bash -l {0}
+        shell: bash -le {0}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: check for upstream branch

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,13 +10,14 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: '3.8'
       - name: Install dependencies
         run: |
+          python --version
           python -m pip install --upgrade pip
           pip install setuptools wheel twine
       - name: Build and publish

--- a/src/vivarium_cluster_tools/psimulate/model_specification.py
+++ b/src/vivarium_cluster_tools/psimulate/model_specification.py
@@ -72,9 +72,11 @@ def parse(
         try:
             parse_artifact_path_config(model_specification.configuration)
         except ConfigurationKeyError:
-            logger.debug("No artifact detected in arguments or configuration. This may"
-                         " be intentional. If not, supply one with the `-i` flag or in"
-                         " the configuration yaml.")
+            logger.debug(
+                "No artifact detected in arguments or configuration. This may"
+                " be intentional. If not, supply one with the `-i` flag or in"
+                " the configuration yaml."
+            )
 
     return model_specification
 

--- a/src/vivarium_cluster_tools/psimulate/paths.py
+++ b/src/vivarium_cluster_tools/psimulate/paths.py
@@ -80,7 +80,9 @@ class OutputPaths(NamedTuple):
 
         output_directory = result_directory
         if command == COMMANDS.run:
-            model_name = get_output_model_name_string(input_artifact_path, input_model_spec_path)
+            model_name = get_output_model_name_string(
+                input_artifact_path, input_model_spec_path
+            )
             output_directory = output_directory / model_name / launch_time
         elif command == COMMANDS.load_test:
             output_directory = output_directory / launch_time

--- a/src/vivarium_cluster_tools/psimulate/worker/load_test_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/load_test_work_horse.py
@@ -22,10 +22,7 @@ LOAD_TEST_WORK_HORSE_IMPORT_PATH = f"{__name__}.work_horse"
 
 
 def get_psimulate_test_dict():
-    return {
-        "sleep": sleep_test,
-        "large_results": large_results_test
-    }
+    return {"sleep": sleep_test, "large_results": large_results_test}
 
 
 def sleep_test(job_parameters: JobParameters) -> pd.DataFrame:
@@ -45,9 +42,7 @@ def sleep_test(job_parameters: JobParameters) -> pd.DataFrame:
 def large_results_test(job_parameters: JobParameters) -> pd.DataFrame:
     time.sleep(30)
     np.random.seed(seed=get_hash(f"large_results_test_{job_parameters.random_seed}"))
-    return pd.DataFrame(
-        np.random.random(10_000_000).reshape((1_000_000, 10))
-    )
+    return pd.DataFrame(np.random.random(10_000_000).reshape((1_000_000, 10)))
 
 
 def work_horse(job_parameters: dict) -> pd.DataFrame:


### PR DESCRIPTION
## Update CI, readme

### Description
- *Category*: other
- *JIRA issue*: [MIC-3690](https://jira.ihme.washington.edu/browse/MIC-3690)

NOTE: These changes were previously approved but accidentally merged into
`main` (https://github.com/ihmeuw/vivarium_cluster_tools/pull/161).
I reset `main` and moved the work into a new branch to properly
merge into `develop`.

This addresses a few issues with the github actions:
* Updates the python builds 3.7-3.10 (remove 3.6 and add 3.9-10)
* Update actions to stop future warnings (The `set-output` command
    is deprecated and will be disabled soon. Please upgrade to using
    Environment Files. For more information see: 
    https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)
* Update CODEOWNERS
* Update README install 3.10
* Update setup to use min 3.7

### Testing
All tests passed and warnings are gone