### PR TITLE
Prevent sorting of model specification keys 

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/model_specification.py
+++ b/src/vivarium_cluster_tools/psimulate/model_specification.py
@@ -85,4 +85,6 @@ def persist(
     model_specification: ConfigTree,
     model_specification_path: Path,
 ) -> None:
-    model_specification_path.write_text(yaml.dump(model_specification.to_dict(), sort_keys=False))
+    model_specification_path.write_text(
+        yaml.dump(model_specification.to_dict(), sort_keys=False)
+    )

--- a/src/vivarium_cluster_tools/psimulate/model_specification.py
+++ b/src/vivarium_cluster_tools/psimulate/model_specification.py
@@ -85,4 +85,4 @@ def persist(
     model_specification: ConfigTree,
     model_specification_path: Path,
 ) -> None:
-    model_specification_path.write_text(yaml.dump(model_specification.to_dict()))
+    model_specification_path.write_text(yaml.dump(model_specification.to_dict(), sort_keys=False))


### PR DESCRIPTION
## Prevent sorting of model specification keys 

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-3889](https://jira.ihme.washington.edu/browse/MIC-3889)

### Changes and notes
While ConfigTree and Dict will preserve insertion order, yaml.dump does not by default. Because of this, it was sorting keys before writing out to the file that all the parallel workers would use. This change prevents that behavior.

### Testing
Visually inspected model_specification.yaml generated and simulation setup ordering between simulate and psimulate runs. The ordering was identical. Also ran identical simulations configuration-wise (seed, draw, etc.) across simulate and psimulate. Results were identical.

