### PR TITLE
Allow specification of draws in branches file

### DIFF
--- a/docs/source/branch.rst
+++ b/docs/source/branch.rst
@@ -48,7 +48,7 @@ This key refers to an integer that represents the number of different input draw
 
 .. note::
     Instead of, or in addition to, specifying an ``input_draw_count``, a list of draws can be specified using the
-    ``input_draws`` key. If ``input_draw_count`` is also specified, the two values are expected to agree, i.e., the
+    ``input_draws`` key. If ``input_draw_count`` is also specified, the two values must agree, i.e., the
     length of the ``input_draws`` list must be the same as ``input_draw_count``.
 
 When we use this branch configuration along with the original :term:`model specification<Model Specification>`,

--- a/docs/source/branch.rst
+++ b/docs/source/branch.rst
@@ -46,6 +46,11 @@ This key refers to an integer that represents the number of different input draw
 
     input_draw_count: 10
 
+.. note::
+    Instead of, or in addition to, specifying an ``input_draw_count``, a list of draws can be specified using the
+    ``input_draws`` key. If ``input_draw_count`` is also specified, the two values are expected to agree, i.e., the
+    length of the ``input_draws`` list must be the same as ``input_draw_count``.
+
 When we use this branch configuration along with the original :term:`model specification<Model Specification>`,
 we'll launch 10 simulations in parallel, each using a different set of input parameters represented by the
 draw number.
@@ -53,7 +58,6 @@ draw number.
 .. code-block:: sh
 
   psimulate run /path/to/model_specification.yaml /path/to/parameter_uncertainty_branches.yaml
-
 
 .. note::
 

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -57,6 +57,7 @@ class Keyspace:
         branches_path: Path,
         extras: Dict,
     ) -> "Keyspace":
+        breakpoint()
         if input_branch_configuration_path is not None:
             keyspace = cls.from_branch_configuration(
                 input_branch_configuration_path,
@@ -207,7 +208,7 @@ def load_branch_configuration(path: Path) -> Tuple[List[Dict], int, int]:
 
     input_draw_count = data.get("input_draw_count", 1)
     random_seed_count = data.get("random_seed_count", 1)
-    # TODO XXX add reading of input_draw_list here
+    # TODO XXX add reading of list here
     breakpoint()
 
     assert input_draw_count <= 1000, "Cannot use more that 1000 draws from GBD"

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -34,13 +34,22 @@ class Keyspace:
         branch_configuration_file
             Absolute path to the branch configuration file.
         """
-        branches, input_draw_count, random_seed_count = load_branch_configuration(
-            branch_configuration_file
-        )
+        (
+            branches,
+            input_draw_count,
+            random_seed_count,
+            input_draws,
+        ) = load_branch_configuration(branch_configuration_file)
         keyspace = calculate_keyspace(branches)
-        keyspace["input_draw"] = calculate_input_draws(input_draw_count)
+        if input_draws:
+            # input_draws were specified
+            keyspace["input_draw"] = input_draws
+        else:
+            # input_draws weren't specified
+            keyspace["input_draw"] = calculate_input_draws(input_draw_count)
         keyspace["random_seed"] = calculate_random_seeds(random_seed_count)
-
+        # XXXX
+        breakpoint()
         return Keyspace(branches, keyspace)
 
     @classmethod
@@ -202,22 +211,34 @@ def calculate_keyspace(branches: List[Dict]) -> Dict:
     return keyspace
 
 
-def load_branch_configuration(path: Path) -> Tuple[List[Dict], int, int]:
+def load_branch_configuration(path: Path) -> Tuple[List[Dict], int, int, Optional[List[int]]]:
     data = yaml.full_load(path.read_text())
 
     input_draw_count = data.get("input_draw_count", 1)
     random_seed_count = data.get("random_seed_count", 1)
-    # TODO XXX add reading of list here
-    breakpoint()
+    input_draws = data.get("input_draws", None)
 
-    assert input_draw_count <= 1000, "Cannot use more that 1000 draws from GBD"
+    # Validate configuration of input_draws and input_draw_count
+    if "input_draw_count" in data and "input_draws" in data:
+        if len(input_draws) != input_draw_count:
+            raise ValueError(
+                f"Both input_draw_count and input_draws are defined but they are inconsistent. "
+                f"input_draw_count is {input_draw_count} while input_draws has length {len(input_draws)}. "
+            )
+    if input_draws:
+        if [d for d in input_draws if d not in range(0, 1000)]:
+            raise ValueError(
+                f"input_draws contains draws outside of 0-999: {[d for d in input_draws if d not in range(0, 1000)]}"
+            )
+    if input_draw_count < 1 or input_draw_count > 1000:
+        raise ValueError(f"Must use 1-1000 draws from GBD")
 
     if "branches" in data:
         branches = expand_branch_templates(data["branches"])
     else:
         branches = [{}]
 
-    return branches, input_draw_count, random_seed_count
+    return branches, input_draw_count, random_seed_count, input_draws
 
 
 def expand_branch_templates(templates: Dict) -> List[Dict]:

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -226,7 +226,7 @@ def load_branch_configuration(path: Path) -> Tuple[List[Dict], int, int, Optiona
                 f"input_draws contains draws outside of 0-999: {[d for d in input_draws if d not in range(0, 1000)]}"
             )
     if input_draw_count < 1 or input_draw_count > 1000:
-        raise ValueError(f"Must use 1-1000 draws from GBD")
+        raise ValueError(f"input_draw_count must be within 1-1000. Given: {input_draw_count}")
 
     if "branches" in data:
         branches = expand_branch_templates(data["branches"])

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -57,7 +57,6 @@ class Keyspace:
         branches_path: Path,
         extras: Dict,
     ) -> "Keyspace":
-        breakpoint()
         if input_branch_configuration_path is not None:
             keyspace = cls.from_branch_configuration(
                 input_branch_configuration_path,

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -41,7 +41,9 @@ class Keyspace:
             input_draws,
         ) = load_branch_configuration(branch_configuration_file)
         keyspace = calculate_keyspace(branches)
-        keyspace["input_draw"] = input_draws if input_draws else calculate_input_draws(input_draw_count)
+        keyspace["input_draw"] = (
+            input_draws if input_draws else calculate_input_draws(input_draw_count)
+        )
         keyspace["random_seed"] = calculate_random_seeds(random_seed_count)
         return Keyspace(branches, keyspace)
 

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -207,6 +207,8 @@ def load_branch_configuration(path: Path) -> Tuple[List[Dict], int, int]:
 
     input_draw_count = data.get("input_draw_count", 1)
     random_seed_count = data.get("random_seed_count", 1)
+    # TODO XXX add reading of input_draw_list here
+    breakpoint()
 
     assert input_draw_count <= 1000, "Cannot use more that 1000 draws from GBD"
 

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -42,12 +42,6 @@ class Keyspace:
         ) = load_branch_configuration(branch_configuration_file)
         keyspace = calculate_keyspace(branches)
         keyspace["input_draw"] = input_draws if input_draws else calculate_input_draws(input_draw_count)
-        # if input_draws:
-        #     # input_draws were specified
-        #     keyspace["input_draw"] = input_draws
-        # else:
-        #     # input_draws weren't specified
-        #     keyspace["input_draw"] = calculate_input_draws(input_draw_count)
         keyspace["random_seed"] = calculate_random_seeds(random_seed_count)
         return Keyspace(branches, keyspace)
 

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -41,15 +41,14 @@ class Keyspace:
             input_draws,
         ) = load_branch_configuration(branch_configuration_file)
         keyspace = calculate_keyspace(branches)
-        if input_draws:
-            # input_draws were specified
-            keyspace["input_draw"] = input_draws
-        else:
-            # input_draws weren't specified
-            keyspace["input_draw"] = calculate_input_draws(input_draw_count)
+        keyspace["input_draw"] = input_draws if input_draws else calculate_input_draws(input_draw_count)
+        # if input_draws:
+        #     # input_draws were specified
+        #     keyspace["input_draw"] = input_draws
+        # else:
+        #     # input_draws weren't specified
+        #     keyspace["input_draw"] = calculate_input_draws(input_draw_count)
         keyspace["random_seed"] = calculate_random_seeds(random_seed_count)
-        # XXXX
-        breakpoint()
         return Keyspace(branches, keyspace)
 
     @classmethod

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -142,7 +142,6 @@ def main(
     )
     # Parse the branches configuration into a parameter space
     # and a flat representation of all parameters to be run.
-    breakpoint()
     keyspace = branches.Keyspace.from_entry_point_args(
         input_branch_configuration_path=input_paths.branch_configuration,
         keyspace_path=output_paths.keyspace,

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -142,6 +142,7 @@ def main(
     )
     # Parse the branches configuration into a parameter space
     # and a flat representation of all parameters to be run.
+    breakpoint()
     keyspace = branches.Keyspace.from_entry_point_args(
         input_branch_configuration_path=input_paths.branch_configuration,
         keyspace_path=output_paths.keyspace,


### PR DESCRIPTION
## Allow specification of draws in branches file

### Description
- *Category*: feature
- *JIRA issue*: [MIC-4106](https://jira.ihme.washington.edu/browse/MIC-4106)

### Changes and notes
- Adds handling of a new `input_draws` key, which allows for specifying a list of draws
- Adds checking for valid values, raising exception (and thus failing) before executing the parallel run
- Updates documentation to note `input_draws` alongside existing `input_draw_count` documentation

### Testing
Tested manually happy cases (specifying copacetic input_draws and input_draw_count values) and failure cases (values mismatch, draws outside of range(0,1000).

