### PR TITLE
fixes for make_artifacts

### DIFF
--- a/src/vivarium_cluster_tools/__init__.py
+++ b/src/vivarium_cluster_tools/__init__.py
@@ -6,4 +6,4 @@ vivarium_cluster_tools
 Tools for working with :mod:`vivarium` on compute clusters.
 
 """
-from vivarium_cluster_tools.utilities import mkdir
+from vivarium_cluster_tools.utilities import get_cluster_name, mkdir

--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -9,9 +9,10 @@ import atexit
 import os
 import shutil
 from pathlib import Path
-from typing import Any, NamedTuple, TextIO
+from typing import NamedTuple, TextIO
 
 from vivarium_cluster_tools.psimulate.environment import ENV_VARIABLES
+from vivarium_cluster_tools.utilities import get_drmaa
 
 
 def validate_cluster_environment() -> None:
@@ -50,7 +51,7 @@ def submit_worker_jobs(
     cluster_logging_root: Path,
     native_specification: NativeSpecification,
 ) -> None:
-    drmaa = _get_drmaa()
+    drmaa = get_drmaa()
     s = drmaa.Session()
     s.initialize()
     jt = s.createJobTemplate()
@@ -83,15 +84,3 @@ def submit_worker_jobs(
                 raise
 
     atexit.register(kill_jobs)
-
-
-def _get_drmaa() -> Any:
-    try:
-        import drmaa
-    except (RuntimeError, OSError):
-        if "slurm" in ENV_VARIABLES.HOSTNAME.value:
-            ENV_VARIABLES.DRMAA_LIB_PATH.update("/opt/slurm-drmaa/lib/libdrmaa.so")
-            import drmaa
-        else:
-            drmaa = object()
-    return drmaa

--- a/src/vivarium_cluster_tools/utilities.py
+++ b/src/vivarium_cluster_tools/utilities.py
@@ -8,10 +8,30 @@ Making directories is hard.
 """
 import functools
 import os
+import socket
 import time
 import warnings
 from pathlib import Path
-from typing import Callable, Union
+from typing import Any, Callable, Union
+
+from vivarium_cluster_tools.psimulate.environment import ENV_VARIABLES
+
+
+def get_cluster_name() -> str:
+    """Returns the hostname"""
+    return socket.gethostname()
+
+
+def get_drmaa() -> Any:
+    try:
+        import drmaa
+    except (RuntimeError, OSError):
+        if "slurm" in ENV_VARIABLES.HOSTNAME.value:
+            ENV_VARIABLES.DRMAA_LIB_PATH.update("/opt/slurm-drmaa/lib/libdrmaa.so")
+            import drmaa
+        else:
+            drmaa = object()
+    return drmaa
 
 
 def mkdir(


### PR DESCRIPTION
## Title: Fixes required to run `make_artifacts -l all`

### Description
- *Category*: bugfix
- *JIRA issue*: [MIC-4136](https://jira.ihme.washington.edu/browse/MIC-4136)

### Changes and notes
VCT is broken in two ways wrt calling `make_artifacts -l all` (from the repo template):
1. The vct function to check if we are on the cluster does not even exist. This
  results in the call always running in serial.
2. The parallel job-launcher never got updated to slurm.

NOTE: this goes hand-in-hand with [this repo template PR](https://github.com/ihmeuw/vivarium_research_template/pull/48)

### Testing
I successfully ran `make_artifacts -l all` on all 51 CVD locations.

