### PR TITLE
Allow specification of random seeds in branches file

### DIFF
--- a/docs/source/branch.rst
+++ b/docs/source/branch.rst
@@ -101,6 +101,10 @@ we'll launch 100 simulations in parallel, each using a different random seed.
 
   psimulate run /path/to/model_specification.yaml /path/to/stochastic_uncertainty_branches.yaml
 
+.. note::
+    Instead of, or in addition to, specifying an ``random_seed_count``, a list of seeds can be specified using the
+    ``random_seeds`` key. If ``random_seed_count`` is also specified, the two values must agree, i.e., the
+    length of the ``random_seeds`` list must be the same as ``random_seed_count``.
 
 Combining Draws and Seeds
 ^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -274,7 +274,7 @@ def _check_count_and_values(
     if values:
         if [d for d in values if d not in range(0, max_count)]:
             raise ValueError(
-                f"{values} contains draws outside of 0-{max_count - 1}: "
+                f"{values_name} contains draws outside of 0-{max_count - 1}: "
                 f"{[d for d in values if d not in range(0, max_count)]}"
             )
     if value_count < 1 or value_count > max_count:

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -219,12 +219,12 @@ def load_branch_configuration(
     input_draws = data.get("input_draws", None)
     random_seeds = data.get("random_seeds", None)
 
-    # Validate configuration of input_draws and input_draw_count
+    # Validate configuration of counts and values for input_draws and random_seeds
     _check_count_and_values(
-        data.columns, input_draw_count, input_draws, "input_draw_count", "input_draws", 1000
+        data, input_draw_count, input_draws, "input_draw_count", "input_draws", 1000
     )
     _check_count_and_values(
-        data.columns,
+        data,
         random_seed_count,
         random_seeds,
         "random_seed_count",
@@ -241,7 +241,7 @@ def load_branch_configuration(
 
 
 def _check_count_and_values(
-    columns: List[str],
+    configuration: Dict,
     value_count: int,
     values: List[int],
     count_name: str,
@@ -252,26 +252,20 @@ def _check_count_and_values(
 
     Parameters
     ----------
-    columns
-        List of column strings in the data.
-
+    configuration
+        Dictionary of the configuration data.
     value_count
         Integer for the number of values provided.
-
     values
         List of integer values.
-
     count_name
         Configuration key string for value count.
-
     values_name
         Configuration key string for values list.
-
     max_count
         Integer for the maximum number of values, maximum value is max_count - 1.
-
     """
-    if count_name in columns and values_name in columns:
+    if count_name in configuration and values_name in configuration:
         if len(values) != value_count:
             raise ValueError(
                 f"Both {count_name} and {values_name} are defined but they are inconsistent. "

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -39,12 +39,15 @@ class Keyspace:
             input_draw_count,
             random_seed_count,
             input_draws,
+            random_seeds,
         ) = load_branch_configuration(branch_configuration_file)
         keyspace = calculate_keyspace(branches)
         keyspace["input_draw"] = (
             input_draws if input_draws else calculate_input_draws(input_draw_count)
         )
-        keyspace["random_seed"] = calculate_random_seeds(random_seed_count)
+        keyspace["random_seed"] = (
+            random_seeds if random_seeds else calculate_random_seeds(random_seed_count)
+        )
         return Keyspace(branches, keyspace)
 
     @classmethod
@@ -206,34 +209,82 @@ def calculate_keyspace(branches: List[Dict]) -> Dict:
     return keyspace
 
 
-def load_branch_configuration(path: Path) -> Tuple[List[Dict], int, int, Optional[List[int]]]:
+def load_branch_configuration(
+    path: Path,
+) -> Tuple[List[Dict], int, int, Optional[List[int]], Optional[List[int]]]:
     data = yaml.full_load(path.read_text())
 
     input_draw_count = data.get("input_draw_count", 1)
     random_seed_count = data.get("random_seed_count", 1)
     input_draws = data.get("input_draws", None)
+    random_seeds = data.get("random_seeds", None)
 
     # Validate configuration of input_draws and input_draw_count
-    if "input_draw_count" in data and "input_draws" in data:
-        if len(input_draws) != input_draw_count:
-            raise ValueError(
-                f"Both input_draw_count and input_draws are defined but they are inconsistent. "
-                f"input_draw_count is {input_draw_count} while input_draws has length {len(input_draws)}. "
-            )
-    if input_draws:
-        if [d for d in input_draws if d not in range(0, 1000)]:
-            raise ValueError(
-                f"input_draws contains draws outside of 0-999: {[d for d in input_draws if d not in range(0, 1000)]}"
-            )
-    if input_draw_count < 1 or input_draw_count > 1000:
-        raise ValueError(f"input_draw_count must be within 1-1000. Given: {input_draw_count}")
+    _check_count_and_values(
+        data.columns, input_draw_count, input_draws, "input_draw_count", "input_draws", 1000
+    )
+    _check_count_and_values(
+        data.columns,
+        random_seed_count,
+        random_seeds,
+        "random_seed_count",
+        "random_seeds",
+        10000,
+    )
 
     if "branches" in data:
         branches = expand_branch_templates(data["branches"])
     else:
         branches = [{}]
 
-    return branches, input_draw_count, random_seed_count, input_draws
+    return branches, input_draw_count, random_seed_count, input_draws, random_seeds
+
+
+def _check_count_and_values(
+    columns: List[str],
+    value_count: int,
+    values: List[int],
+    count_name: str,
+    values_name: str,
+    max_count: int,
+):
+    """Checks input configuration count and values for integers outside of range.
+
+    Parameters
+    ----------
+    columns
+        List of column strings in the data.
+
+    value_count
+        Integer for the number of values provided.
+
+    values
+        List of integer values.
+
+    count_name
+        Configuration key string for value count.
+
+    values_name
+        Configuration key string for values list.
+
+    max_count
+        Integer for the maximum number of values, maximum value is max_count - 1.
+
+    """
+    if count_name in columns and values_name in columns:
+        if len(values) != value_count:
+            raise ValueError(
+                f"Both {count_name} and {values_name} are defined but they are inconsistent. "
+                f"{count_name} is {value_count} while {values_name} has length {len(values)}. "
+            )
+    if values:
+        if [d for d in values if d not in range(0, max_count)]:
+            raise ValueError(
+                f"{values} contains draws outside of 0-{max_count - 1}: "
+                f"{[d for d in values if d not in range(0, max_count)]}"
+            )
+    if value_count < 1 or value_count > max_count:
+        raise ValueError(f"{count_name} must be within 1-{max_count}. Given: {value_count}")
 
 
 def expand_branch_templates(templates: Dict) -> List[Dict]:


### PR DESCRIPTION
## Allow specification of random seeds in branches file

### Description
- *Category*: feature
- *JIRA issue*: [MIC-4107](https://jira.ihme.washington.edu/browse/MIC-4107)

### Changes and notes
- Adds random_seeds key for listing specific random_seeds, similar to the input_draws key.
- Refactors validation of input_draws to be leveraged with random_seeds validation.

### Testing
Tested manually against the IV Iron maternal simulation. I got the expected behavior in the normal case and two failure cases (random_seed_count != len(random_seeds) and if any value in random_seeds is outside of the range (0-9999).

