### PR TITLE
Automate versioning using setuptools_scm

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.rst
 include CHANGELOG.rst
 include setup.py
+include _version.py
 
 recursive-include src/vivarium_cluster_tools/ *.py
 

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,7 +1,6 @@
 include README.rst
 include CHANGELOG.rst
 include setup.py
-include _version.py
 
 recursive-include src/vivarium_cluster_tools/ *.py
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,18 +28,6 @@ about = {}
 with (base_dir / "__about__.py").open() as f:
     exec(f.read(), about)
 
-# _version = {}
-# print(f"base_dir.parent.parent {base_dir.parent.parent}")
-# print(f"base_dir.parent {base_dir.parent}")
-# print(f"base_dir {base_dir}")
-# try:
-#     # with (base_dir.parent.parent / "_version.py").open() as f:
-#     with (base_dir / "_version.py").open() as f:
-#         exec(f.read(), _version)
-# except FileNotFoundError:
-#     raise UserWarning("To make docs, install via setup the official package or from source.")
-
-
 sys.path.insert(0, str(Path("..").resolve()))
 
 # -- Project information -----------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,8 @@ print(f"base_dir.parent.parent {base_dir.parent.parent}")
 print(f"base_dir.parent {base_dir.parent}")
 print(f"base_dir {base_dir}")
 try:
-    with (base_dir.parent.parent / "_version.py").open() as f:
+    # with (base_dir.parent.parent / "_version.py").open() as f:
+    with (base_dir / "_version.py").open() as f:
         exec(f.read(), _version)
 except FileNotFoundError:
     raise UserWarning("To make docs, install via setup the official package or from source.")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,8 @@ with (base_dir / "__about__.py").open() as f:
 _version = {}
 try:
     with (base_dir.parent.parent / "_version.py").open() as f:
+        print(f"base_dir.parent.parent {base_dir.parent.parent}")
+        print(f"base_dir.parent {base_dir.parent}")
         exec(f.read(), _version)
 except FileNotFoundError:
     raise UserWarning("To make docs, install via setup the official package or from source.")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -31,6 +31,7 @@ with (base_dir / "__about__.py").open() as f:
 _version = {}
 print(f"base_dir.parent.parent {base_dir.parent.parent}")
 print(f"base_dir.parent {base_dir.parent}")
+print(f"base_dir {base_dir}")
 try:
     with (base_dir.parent.parent / "_version.py").open() as f:
         exec(f.read(), _version)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,10 +29,10 @@ with (base_dir / "__about__.py").open() as f:
     exec(f.read(), about)
 
 _version = {}
+print(f"base_dir.parent.parent {base_dir.parent.parent}")
+print(f"base_dir.parent {base_dir.parent}")
 try:
     with (base_dir.parent.parent / "_version.py").open() as f:
-        print(f"base_dir.parent.parent {base_dir.parent.parent}")
-        print(f"base_dir.parent {base_dir.parent}")
         exec(f.read(), _version)
 except FileNotFoundError:
     raise UserWarning("To make docs, install via setup the official package or from source.")

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,16 +28,16 @@ about = {}
 with (base_dir / "__about__.py").open() as f:
     exec(f.read(), about)
 
-_version = {}
-print(f"base_dir.parent.parent {base_dir.parent.parent}")
-print(f"base_dir.parent {base_dir.parent}")
-print(f"base_dir {base_dir}")
-try:
-    # with (base_dir.parent.parent / "_version.py").open() as f:
-    with (base_dir / "_version.py").open() as f:
-        exec(f.read(), _version)
-except FileNotFoundError:
-    raise UserWarning("To make docs, install via setup the official package or from source.")
+# _version = {}
+# print(f"base_dir.parent.parent {base_dir.parent.parent}")
+# print(f"base_dir.parent {base_dir.parent}")
+# print(f"base_dir {base_dir}")
+# try:
+#     # with (base_dir.parent.parent / "_version.py").open() as f:
+#     with (base_dir / "_version.py").open() as f:
+#         exec(f.read(), _version)
+# except FileNotFoundError:
+#     raise UserWarning("To make docs, install via setup the official package or from source.")
 
 
 sys.path.insert(0, str(Path("..").resolve()))
@@ -49,9 +49,9 @@ copyright = f'2021, {about["__author__"]}'
 author = about["__author__"]
 
 # The short X.Y version.
-version = _version["__version__"]
+version = vivarium_cluster_tools.__version__
 # The full version, including alpha/beta/rc tags.
-release = _version["__version__"]
+release = vivarium_cluster_tools.__version__
 
 
 # -- General configuration ------------------------------------------------

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -28,6 +28,14 @@ about = {}
 with (base_dir / "__about__.py").open() as f:
     exec(f.read(), about)
 
+_version = {}
+try:
+    with (base_dir.parent.parent / "_version.py").open() as f:
+        exec(f.read(), _version)
+except FileNotFoundError:
+    raise UserWarning("To make docs, install via setup the official package or from source.")
+
+
 sys.path.insert(0, str(Path("..").resolve()))
 
 # -- Project information -----------------------------------------------------
@@ -37,9 +45,9 @@ copyright = f'2021, {about["__author__"]}'
 author = about["__author__"]
 
 # The short X.Y version.
-version = about["__version__"]
+version = _version["__version__"]
 # The full version, including alpha/beta/rc tags.
-release = about["__version__"]
+release = _version["__version__"]
 
 
 # -- General configuration ------------------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@ import os
 from setuptools import find_packages, setup
 
 if __name__ == "__main__":
-
     base_dir = os.path.dirname(__file__)
     src_dir = os.path.join(base_dir, "src")
 
@@ -29,9 +28,7 @@ if __name__ == "__main__":
         "requests",
     ]
 
-    setup_requires = [
-        "setuptools_scm"
-    ]
+    setup_requires = ["setuptools_scm"]
 
     test_requirements = [
         "pytest",

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,10 @@ if __name__ == "__main__":
         "requests",
     ]
 
+    setup_requires = [
+        "setuptools_scm"
+    ]
+
     test_requirements = [
         "pytest",
         "pytest-mock",
@@ -44,7 +48,6 @@ if __name__ == "__main__":
 
     setup(
         name=about["__title__"],
-        version=about["__version__"],
         description=about["__summary__"],
         long_description=long_description,
         url=about["__uri__"],
@@ -65,4 +68,10 @@ if __name__ == "__main__":
             "dev": doc_requirements + test_requirements,
         },
         zip_safe=False,
+        use_scm_version={
+            "write_to": "_version.py",
+            "write_to_template": '__version__ = "{version}"',
+            "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
+        },
+        setup_requires=setup_requires,
     )

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ if __name__ == "__main__":
         use_scm_version={
             "write_to": "src/vivarium_cluster_tools/_version.py",
             # "write_to": "_version.py",
-            "write_to_template": '__version__ = "{version}"',
+            "write_to_template": '__version__ = "{version}"\n',
             "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
         },
         setup_requires=setup_requires,

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,6 @@ if __name__ == "__main__":
         zip_safe=False,
         use_scm_version={
             "write_to": "src/vivarium_cluster_tools/_version.py",
-            # "write_to": "_version.py",
             "write_to_template": '__version__ = "{version}"\n',
             "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
         },

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,8 @@ if __name__ == "__main__":
         },
         zip_safe=False,
         use_scm_version={
-            "write_to": "_version.py",
+            "write_to": "src/vivarium_cluster_tools/_version.py",
+            # "write_to": "_version.py",
             "write_to_template": '__version__ = "{version}"',
             "tag_regex": r"^(?P<prefix>v)?(?P<version>[^\+]+)(?P<suffix>.*)?$",
         },

--- a/src/vivarium_cluster_tools/__about__.py
+++ b/src/vivarium_cluster_tools/__about__.py
@@ -11,7 +11,5 @@ __title__ = "vivarium_cluster_tools"
 __summary__ = "A set of tools for running simulation using vivarium on cluster."
 __uri__ = "https://github.com/ihmeuw/vivarium_cluster_tools"
 
-__version__ = "1.3.9"
-
 __author__ = "The vivarium developers"
 __email__ = "vivarium.dev@gmail.com"

--- a/src/vivarium_cluster_tools/__about__.py
+++ b/src/vivarium_cluster_tools/__about__.py
@@ -2,7 +2,6 @@ __all__ = [
     "__title__",
     "__summary__",
     "__uri__",
-    "__version__",
     "__author__",
     "__email__",
 ]

--- a/src/vivarium_cluster_tools/__init__.py
+++ b/src/vivarium_cluster_tools/__init__.py
@@ -6,5 +6,5 @@ vivarium_cluster_tools
 Tools for working with :mod:`vivarium` on compute clusters.
 
 """
-from vivarium_cluster_tools.utilities import get_cluster_name, mkdir
 from vivarium_cluster_tools._version import __version__
+from vivarium_cluster_tools.utilities import get_cluster_name, mkdir

--- a/src/vivarium_cluster_tools/__init__.py
+++ b/src/vivarium_cluster_tools/__init__.py
@@ -7,3 +7,4 @@ Tools for working with :mod:`vivarium` on compute clusters.
 
 """
 from vivarium_cluster_tools.utilities import get_cluster_name, mkdir
+from vivarium_cluster_tools._version import __version__


### PR DESCRIPTION
## Automate versioning using setuptools_scm

### Description
- *Category*: POC
- *JIRA issue*: [MIC-4167](https://jira.ihme.washington.edu/browse/MIC-4167)

### Changes and notes
Adds usage of setuptools_scm. Most of the defaults work for our use case:
* Releases where there are no changes between the latest version tag will get the version and no other information. This is PyPI compliant.
* When we have revisions after the tag, or the work area is "dirty", you'll get the distance (number of revisions) and the latest git commit, e.g, 1.3.10.dev2+g1de891c, where the last tag is v1.3.9, 2 commits since that tag and the latest commit is 1de891c.

The `use_scm_version` block in `setup.py` is taken from [an example in the documentation](https://github.com/pypa/setuptools_scm#configuration-parameters). `use_scm_version` says to use setuptools scm, `write_to` and `write_to_template` manages the `_version.py` file writing. The `tag_regex` matches tags of valid version names, used in discerning the current version. This regex could be paired back, since we'll never release a version that has a `+` segment (PyPI disallows this AFAIK), but it's not necessary, since picking the version tag is still (and intentionally) a manual process.

### Testing
Works manually. Tested with `python setup.py --version` and `pip install`.
