### PR TITLE
get matching upstream branch during CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,16 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
+      - name: get upstream branch name
+        run: |
+          if "${{ github.event_name == 'pull_request' }}" ; then
+            echo "branch_name=${GITHUB_HEAD_REF}" >> $GITHUB_ENV
+          else
+            echo "branch_name=${GITHUB_REF_NAME}" >> $GITHUB_ENV
+          fi
       - name: check for upstream branch
         run: |
-          if git ls-remote --exit-code --heads https://github.com/ihmeuw/vivarium.git ${GITHUB_HEAD_REF} == "0"; then
+          if git ls-remote --exit-code --heads https://github.com/ihmeuw/vivarium.git ${branch_name} == "0"; then
             echo "upstream_exist=true" >> $GITHUB_ENV
           else
             echo "upstream_exist=false" >> $GITHUB_ENV
@@ -37,8 +44,8 @@ jobs:
       - name: Retrieve upstream branch if exists
         if: env.upstream_exist == 'true'
         run: |
-          echo "Cloning upstream branch: ${GITHUB_HEAD_REF}"
-          git clone --branch=${GITHUB_HEAD_REF} https://github.com/ihmeuw/vivarium.git
+          echo "Cloning upstream branch: ${branch_name}"
+          git clone --branch=${branch_name} https://github.com/ihmeuw/vivarium.git
           pushd vivarium
           pip install .
           popd


### PR DESCRIPTION
## Update CI to use vivarium branch if it exists
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: CI/infrastructure
- *JIRA issue*: [MIC-4363](https://jira.ihme.washington.edu/browse/MIC-4363)

### Changes and notes
Use `GITHUB_REF_NAME` environment variable to look for a matching vivarium branch

### Testing
Ran CI and checked logs to see that correct vivarium branch is checked out.

