### PR TITLE
Make failures more visible

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.3.11 - 09/07/23**
+
+ - Made job failures more prominent in end of jobs logging
+
 **1.3.10 - 07/12/23**
 
  - Allow for specifying random seeds and draws in branches file

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -258,5 +258,6 @@ def main(
         )
 
     logger.info(
-        f"{status['finished']} of {status['total']} jobs completed. Results written to: {str(output_paths.root)}"
+        f"{status['finished']} of {status['total']} jobs completed successfully. "
+        f"Results written to: {str(output_paths.root)}"
     )

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -54,7 +54,8 @@ def process_job_results(
                     batch_size,
                 )
 
-            registry_manager.update_and_report()
+            status = registry_manager.update_and_report()
+            breakpoint()
             logger.info(f"Unwritten results: {len(unwritten_results)}")
             logger.info(f"Elapsed time: {(time() - start_time)/60:.1f} minutes.")
     finally:
@@ -247,6 +248,5 @@ def main(
 
     # Spit out a performance report for the workers.
     try_run_vipin(output_paths.worker_logging_root)
-    registry_manager.update_and_report()
 
     logger.info(f"Jobs completed. Results written to: {str(output_paths.root)}")

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -249,18 +249,13 @@ def main(
 
     # Spit out a performance report for the workers.
     try_run_vipin(output_paths.worker_logging_root)
-
-    template = (
-        "Final status - Total jobs: {total}, % Done: {done:.2f}% "
-        "Pending: {pending}, Running: {running}, Failed: {failed}, Finished: {finished} "
-        "Workers: {workers}."
-    )
     breakpoint()
-    logger.info(template.format(**status))
     if status["failed"] > 0:
         logger.warning(
-            f"*** There {'was' if status['failed'] == 1 else 'were'} "
-            f"{status['failed']} failure{'' if status['failed'] == 1 else 's'}. ***"
+            f"*** NOTE: There {'was' if status['failed'] == 1 else 'were'} "
+            f"{status['failed']} failed job{'' if status['failed'] == 1 else 's'}. ***"
         )
 
-    logger.info(f"Jobs completed. Results written to: {str(output_paths.root)}")
+    logger.info(
+        f"{status['finished']} jobs completed. Results written to: {str(output_paths.root)}"
+    )

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -249,7 +249,8 @@ def main(
 
     # Spit out a performance report for the workers.
     try_run_vipin(output_paths.worker_logging_root)
-    breakpoint()
+
+    # Emit warning if any jobs failed
     if status["failed"] > 0:
         logger.warning(
             f"*** NOTE: There {'was' if status['failed'] == 1 else 'were'} "
@@ -257,5 +258,5 @@ def main(
         )
 
     logger.info(
-        f"{status['finished']} jobs completed. Results written to: {str(output_paths.root)}"
+        f"{status['finished']} of {status['total']} jobs completed. Results written to: {str(output_paths.root)}"
     )

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -249,13 +249,18 @@ def main(
 
     # Spit out a performance report for the workers.
     try_run_vipin(output_paths.worker_logging_root)
+
     template = (
         "Final status - Total jobs: {total}, % Done: {done:.2f}% "
         "Pending: {pending}, Running: {running}, Failed: {failed}, Finished: {finished} "
         "Workers: {workers}."
     )
-
+    breakpoint()
     logger.info(template.format(**status))
     if status["failed"] > 0:
-        logger.warning(f"*** There {'was' if status['failed'] == 1 else 'were'} {status['failed']} failure{'' if status['failed'] == 1 else 's'}. ***")
+        logger.warning(
+            f"*** There {'was' if status['failed'] == 1 else 'were'} "
+            f"{status['failed']} failure{'' if status['failed'] == 1 else 's'}. ***"
+        )
+
     logger.info(f"Jobs completed. Results written to: {str(output_paths.root)}")

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -247,5 +247,6 @@ def main(
 
     # Spit out a performance report for the workers.
     try_run_vipin(output_paths.worker_logging_root)
+    registry_manager.update_and_report()
 
     logger.info(f"Jobs completed. Results written to: {str(output_paths.root)}")


### PR DESCRIPTION
## Make failures more visible

### Description
- *Category*:  feature
- *JIRA issue*: [MIC-4265](https://jira.ihme.washington.edu/browse/MIC-4265)

### Changes and notes
- Adds a warning at psimulate epilogue if there were failed jobs
- Updates final job completion log message to include status (finished/total)

### Testing
Ran against a stripped down vivarium_gates_nutrition_optimization sim, adding breakpoints to insert failiures into the status. Exit log messages were as expected, in both the happy case and in the failure(s) case.
