### PR TITLE
Allow branch/scenarios.py to configure artifact

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # default owners
-* @albrja @beatrixkh @collijk @hussain-jafari @mattkappel @rmudambi @stevebachmeier
+* @albrja @beatrixkh @collijk @hussain-jafari @mattkappel @ramittal @rmudambi @stevebachmeier

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,8 +5,9 @@
 <!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
 - *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                    revert, test, release, other/misc -->
-- *JIRA issue*: <!-- [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-XYZ) -->
+- *JIRA issue*: [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-XYZ)
 
+### Changes and notes
 <!-- 
 Change description – why, what, anything unexplained by the above.
 Include guidance to reviewers if changes are complex.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.3.12 - 09/22/23**
+
+ - Bugfixes for psimulate
+
 **1.3.11 - 09/07/23**
 
  - Made job failures more prominent in end of jobs logging

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -105,6 +105,7 @@ def work_horse(job_parameters: dict) -> pd.DataFrame:
     finally:
         logger.info(f"Exiting job: {job_parameters}")
 
+
 def setup_sim(job_parameters: JobParameters) -> SimulationContext:
     assert job_parameters.branch_configuration is not None
     configuration = ConfigTree(

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -15,6 +15,7 @@ from traceback import format_exc
 import pandas as pd
 from loguru import logger
 from rq import get_current_job
+from vivarium.config_tree import ConfigTree
 from vivarium.framework.engine import SimulationContext
 from vivarium.framework.utilities import collapse_nested_dict
 
@@ -35,7 +36,7 @@ def work_horse(job_parameters: dict) -> pd.DataFrame:
     logger.info(f"Starting job: {job_parameters}")
 
     try:
-        configuration = job_parameters.branch_configuration
+        configuration = ConfigTree(job_parameters.branch_configuration)
         # TODO: Need to test serialization of an empty dict, then this
         #   can go away.  If you're successfully running code and this
         #   assert is still here, delete it.

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -41,22 +41,20 @@ def work_horse(job_parameters: dict) -> pd.DataFrame:
         #   assert is still here, delete it.
         assert configuration is not None
 
-        configuration["run_configuration"].update(
+        configuration.update(
             {
-                "run_id": str(get_current_job().id) + "_" + str(time()),
-                "results_directory": job_parameters.results_path,
-                "run_key": job_parameters.job_specific,
-            }
-        )
-        configuration["randomness"].update(
-            {
-                "random_seed": job_parameters.random_seed,
-                "additional_seed": job_parameters.input_draw,
-            }
-        )
-        configuration["input_data"].update(
-            {
-                "input_draw_number": job_parameters.input_draw,
+                "run_configuration": {
+                    "run_id": str(get_current_job().id) + "_" + str(time()),
+                    "results_directory": job_parameters.results_path,
+                    "run_key": job_parameters.job_specific,
+                },
+                "randomness": {
+                    "random_seed": job_parameters.random_seed,
+                    "additional_seed": job_parameters.input_draw,
+                },
+                "input_data": {
+                    "input_draw_number": job_parameters.input_draw,
+                },
             }
         )
 

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -105,9 +105,7 @@ def work_horse(job_parameters: dict) -> pd.DataFrame:
 
 
 def setup_sim(job_parameters: JobParameters) -> SimulationContext:
-    """Set up a simulation context from a job parameters object, with the
-    branch/job-specific configuration parameters.
-    """
+    """Set up a simulation context with the branch/job-specific configuration parameters."""
     configuration = ConfigTree(
         job_parameters.branch_configuration, layers=["branch_base", "branch_expanded"]
     )

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -64,7 +64,7 @@ def work_horse(job_parameters: dict) -> pd.DataFrame:
         )
 
         sim = SimulationContext(
-            job_parameters.model_specification, configuration=configuration
+            job_parameters.model_specification, configuration=configuration.to_dict()
         )
         logger.info("Simulation configuration:")
         logger.info(str(sim.configuration))

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -36,7 +36,9 @@ def work_horse(job_parameters: dict) -> pd.DataFrame:
     logger.info(f"Starting job: {job_parameters}")
 
     try:
-        configuration = ConfigTree(job_parameters.branch_configuration)
+        configuration = ConfigTree(
+            job_parameters.branch_configuration, layers=["base", "update"]
+        )
         # TODO: Need to test serialization of an empty dict, then this
         #   can go away.  If you're successfully running code and this
         #   assert is still here, delete it.
@@ -56,7 +58,9 @@ def work_horse(job_parameters: dict) -> pd.DataFrame:
                 "input_data": {
                     "input_draw_number": job_parameters.input_draw,
                 },
-            }
+            },
+            layer="update",
+            source="branch_config",
         )
 
         sim = SimulationContext(

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -37,8 +37,6 @@ def work_horse(job_parameters: dict) -> pd.DataFrame:
 
     try:
         sim = setup_sim(job_parameters)
-        logger.info("Simulation configuration:")
-        logger.info(str(sim.configuration))
 
         start_time = pd.Timestamp(**sim.configuration.time.start.to_dict())
         end_time = pd.Timestamp(**sim.configuration.time.end.to_dict())
@@ -107,7 +105,19 @@ def work_horse(job_parameters: dict) -> pd.DataFrame:
 
 
 def setup_sim(job_parameters: JobParameters) -> SimulationContext:
-    assert job_parameters.branch_configuration is not None
+    """Set up a simulation context from a job parameters object, with the
+    branch/job-specific configuration parameters.
+
+    Parameters
+    ----------
+    job_parameters : JobParameters
+        The branch/job-specific configuration parameters.
+
+    Returns
+    -------
+    SimulationContext
+        The simulation context.
+    """
     configuration = ConfigTree(
         job_parameters.branch_configuration, layers=["branch_base", "branch_expanded"]
     )
@@ -131,7 +141,11 @@ def setup_sim(job_parameters: JobParameters) -> SimulationContext:
         source="branch_config",
     )
 
-    return SimulationContext(job_parameters.model_specification, configuration=configuration)
+    sim = SimulationContext(job_parameters.model_specification, configuration=configuration)
+    logger.info("Simulation configuration:")
+    logger.info(str(sim.configuration))
+
+    return sim
 
 
 def do_sim_epilogue(

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -41,20 +41,22 @@ def work_horse(job_parameters: dict) -> pd.DataFrame:
         #   assert is still here, delete it.
         assert configuration is not None
 
-        configuration.update(
+        configuration["run_configuration"].update(
             {
-                "run_configuration": {
-                    "run_id": str(get_current_job().id) + "_" + str(time()),
-                    "results_directory": job_parameters.results_path,
-                    "run_key": job_parameters.job_specific,
-                },
-                "randomness": {
-                    "random_seed": job_parameters.random_seed,
-                    "additional_seed": job_parameters.input_draw,
-                },
-                "input_data": {
-                    "input_draw_number": job_parameters.input_draw,
-                },
+                "run_id": str(get_current_job().id) + "_" + str(time()),
+                "results_directory": job_parameters.results_path,
+                "run_key": job_parameters.job_specific,
+            }
+        )
+        configuration["randomness"].update(
+            {
+                "random_seed": job_parameters.random_seed,
+                "additional_seed": job_parameters.input_draw,
+            }
+        )
+        configuration["input_data"].update(
+            {
+                "input_draw_number": job_parameters.input_draw,
             }
         )
 

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -107,16 +107,6 @@ def work_horse(job_parameters: dict) -> pd.DataFrame:
 def setup_sim(job_parameters: JobParameters) -> SimulationContext:
     """Set up a simulation context from a job parameters object, with the
     branch/job-specific configuration parameters.
-
-    Parameters
-    ----------
-    job_parameters : JobParameters
-        The branch/job-specific configuration parameters.
-
-    Returns
-    -------
-    SimulationContext
-        The simulation context.
     """
     configuration = ConfigTree(
         job_parameters.branch_configuration, layers=["branch_base", "branch_expanded"]

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -108,7 +108,7 @@ def work_horse(job_parameters: dict) -> pd.DataFrame:
 def setup_sim(job_parameters: JobParameters) -> SimulationContext:
     assert job_parameters.branch_configuration is not None
     configuration = ConfigTree(
-        job_parameters.branch_configuration, layers=["base", "update"]
+        job_parameters.branch_configuration, layers=["branch_base", "branch_expanded"]
     )
 
     configuration.update(
@@ -126,7 +126,7 @@ def setup_sim(job_parameters: JobParameters) -> SimulationContext:
                 "input_draw_number": job_parameters.input_draw,
             },
         },
-        layer="update",
+        layer="branch_expanded",
         source="branch_config",
     )
 

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -3,6 +3,7 @@ import pytest
 from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import setup_sim
 from vivarium_cluster_tools.psimulate.jobs import JobParameters
 
+
 def test_setup_sim(mocker):
     mocker.patch(
         "vivarium_cluster_tools.psimulate.worker.vivarium_work_horse.get_current_job",

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -1,0 +1,3 @@
+import pytest
+from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import setup_sim
+from vivarium_cluster_tools.psimulate.jobs import JobParameters

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -3,9 +3,6 @@ import pytest
 from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import setup_sim
 from vivarium_cluster_tools.psimulate.jobs import JobParameters
 
-# from rq import get_current_job
-
-
 def test_setup_sim(mocker):
     mocker.patch(
         "vivarium_cluster_tools.psimulate.worker.vivarium_work_horse.get_current_job",

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -1,3 +1,29 @@
 import pytest
+from pathlib import Path
 from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import setup_sim
 from vivarium_cluster_tools.psimulate.jobs import JobParameters
+
+# from rq import get_current_job
+
+
+def test_setup_sim(mocker):
+    mocker.patch(
+        "vivarium_cluster_tools.psimulate.worker.vivarium_work_horse.get_current_job",
+        return_value=mocker.Mock(id="test_string"),
+    )
+
+    job_parameters = JobParameters(
+        model_specification=None,
+        branch_configuration={
+            "input_data": {"artifact_path": "~/vivarium.yaml"},
+            "time": {"end": {"year": 2020}},
+        },
+        input_draw=1,
+        random_seed=2,
+        results_path="~/tmp",
+        extras={},
+    )
+    sim_config = setup_sim(job_parameters).configuration
+
+    assert sim_config["time"]["end"]["year"] == 2020
+    assert sim_config["input_data"]["artifact_path"] == "~/vivarium.yaml"

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -1,5 +1,5 @@
 import pytest
-from pathlib import Path
+
 from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import setup_sim
 from vivarium_cluster_tools.psimulate.jobs import JobParameters
 

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -1,7 +1,7 @@
 import pytest
 
-from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import setup_sim
 from vivarium_cluster_tools.psimulate.jobs import JobParameters
+from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import setup_sim
 
 
 def test_setup_sim(mocker):


### PR DESCRIPTION
## Allow branch/scenarios.py to configure artifact
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
bugfix
- *JIRA issue*: [MIC-4332](https://jira.ihme.washington.edu/browse/MIC-4332)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Configuring the artifact path in `scenarios.py` does not work, and instead uses whichever artifact path is in the model_spec, even though the artifact path is properly represented in the keyspace.

It turns out to be an issue with a nested dictionary in `vivarium_work_horse.py`:
```
        configuration.update(
            {
                "run_configuration": {
                    "run_id": str(get_current_job().id) + "_" + str(time()),
                    "results_directory": job_parameters.results_path,
                    "run_key": job_parameters.job_specific,
                },
                "randomness": {
                    "random_seed": job_parameters.random_seed,
                    "additional_seed": job_parameters.input_draw,
                },
                "input_data": {
                    "input_draw_number": job_parameters.input_draw,
                },
            }
        )
```
`vivarium` reads in the artifact path from `input_data.artifact_path`, but the above dict update replaces the whole input_data sub-dictionary, and subsequently removes the artifact_path key if it exists. This could be true for `randomness` as well, in general.

The economical thing seems to be to just convert the branch configuration into a `ConfigTree`, which has an update method that performs the update in the manner desired. Just to be safe when performing the update, I added layers and a source for the ConfigTree, These would be overwritten when SimulationContext builds its own fuller configuration with the branch configuration as a component, but to be even safer, I converted the ConfigTree back to a dict before passing into SimulationContext. 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
I tested in MNCH maternal repository that this updates the artifact path based on the scenario input.
`vivarium_work_horse.py` itself does a number of things, and seemed a bit cumbersome to write tests for directly. I would suggest ensuring that the appropriate behavior of the relevant pieces of code are tested in `vivarium`:
 
Vivarium already tests ConfigTree.to_dict(), several other properties of ConfigTree.update(), and writing dictionaries of model spec and user config into SimulationContext. 

I think an additional test needed here, then, is that updating a nested ConfigTree will only overwrite the key we're looking to overwrite (this is kind of baked into ConfigTree, but putting in another `assert` in `test_update_dict_nested()` in configtree's tests in `vivarium` is simple to do)

Per some offline feedback, I added a small test to ensure that we can update the sim config appropriately from the branch file.
