### PR TITLE
Add Max Workers option to throttle jobs

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -83,11 +83,10 @@ shared_options = [
 )
 @click.option(
     "--max-workers",
-    type=click.INT,
+    type=click.IntRange(min=1),
     help="The maximum number of workers (and therefore jobs) to run concurrently."
     "If unset, submit all jobs at once and let the cluster schedule them.",
 )
-
 @cli_tools.pass_shared_options(shared_options)
 def run(
     model_specification: Path,

--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -81,6 +81,13 @@ shared_options = [
     "configuration file.",
     callback=cli_tools.coerce_to_full_path,
 )
+@click.option(
+    "--max-workers",
+    type=click.INT,
+    help="The maximum number of workers (and therefore jobs) to run concurrently."
+    "If unset, submit all jobs at once and let the cluster schedule them.",
+)
+
 @cli_tools.pass_shared_options(shared_options)
 def run(
     model_specification: Path,
@@ -128,7 +135,7 @@ def run(
         ),
         redis_processes=options["redis"],
         no_batch=options["no_batch"],
-        extra_args={},
+        extra_args={"max_workers": options["max_workers"]},
     )
 
 

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/cli_options.py
@@ -9,8 +9,8 @@ Command line options for configuring job/result queue Redis DBs in psimulate run
 import click
 
 from vivarium_cluster_tools.psimulate.redis_dbs.launcher import (
-    DEFAULT_WORKERS_PER_REDIS_INSTANCE,
     DEFAULT_NUM_REDIS_DBS,
+    DEFAULT_WORKERS_PER_REDIS_INSTANCE,
 )
 
 with_redis = click.option(

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/cli_options.py
@@ -9,7 +9,7 @@ Command line options for configuring job/result queue Redis DBs in psimulate run
 import click
 
 from vivarium_cluster_tools.psimulate.redis_dbs.launcher import (
-    DEFAULT_JOBS_PER_REDIS_INSTANCE,
+    DEFAULT_WORKERS_PER_REDIS_INSTANCE,
     DEFAULT_NUM_REDIS_DBS,
 )
 
@@ -19,6 +19,6 @@ with_redis = click.option(
     default=DEFAULT_NUM_REDIS_DBS,
     help=(
         f"Number of redis databases to use.  Defaults to a redis instance for every "
-        f"{DEFAULT_JOBS_PER_REDIS_INSTANCE} jobs."
+        f"{DEFAULT_WORKERS_PER_REDIS_INSTANCE} workers."
     ),
 )

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/launcher.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/launcher.py
@@ -20,15 +20,15 @@ from loguru import logger
 from vivarium_cluster_tools.psimulate.environment import ENV_VARIABLES
 
 DEFAULT_NUM_REDIS_DBS = -1
-DEFAULT_JOBS_PER_REDIS_INSTANCE = 1000
+DEFAULT_WORKERS_PER_REDIS_INSTANCE = 1000
 
 
 def launch_redis_processes(
     num_processes: int,
-    num_jobs: int,
+    num_workers: int,
     redis_logging_root: Path,
 ) -> List[Tuple[str, int]]:
-    num_processes = _get_num_redis_dbs(num_processes, num_jobs)
+    num_processes = _get_num_redis_dbs(num_processes, num_workers)
 
     hostname = ENV_VARIABLES.HOSTNAME.value
     redis_ports = []
@@ -42,9 +42,16 @@ def launch_redis_processes(
     return redis_ports
 
 
-def _get_num_redis_dbs(num_processes: int, num_jobs: int) -> int:
+def _get_num_redis_dbs(num_processes: int, num_workers: int) -> int:
     if num_processes == DEFAULT_NUM_REDIS_DBS:
-        num_processes = int(math.ceil(num_jobs / DEFAULT_JOBS_PER_REDIS_INSTANCE))
+        num_processes = int(math.ceil(num_workers / DEFAULT_WORKERS_PER_REDIS_INSTANCE))
+    elif num_workers <  _expected_sufficient_workers(num_processes):
+        logger.warning(
+            f"With {num_processes} queues, you should have >> {_expected_sufficient_workers(num_processes)} workers,"
+            "but you only have {num_workers}."
+            "Failure to allocate sufficent workers may result in jobs not being processed."
+            "Consider increasing the number of workers, or decreasing the number of redis queues."
+        )
     return num_processes
 
 
@@ -89,3 +96,8 @@ def _get_random_free_port() -> int:
     port = s.getsockname()[1]
     s.close()
     return port
+
+def _expected_sufficient_workers(num_queues) -> int:
+    # Rough estimate of the number of workers needed to ensure that each queue gets
+    # at least one worker. cf. https://w.wiki/7bnb
+    return int(math.ceil(num_queues * (math.log(num_queues) + 0.57)))

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/launcher.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/launcher.py
@@ -49,8 +49,9 @@ def _get_num_redis_dbs(num_processes: int, num_workers: int) -> int:
         min_workers = _expected_sufficient_workers(num_processes)
         if num_workers < min_workers:
             logger.warning(
-                f"With {num_processes} queues, you should have >> {min_workers} workers, but you only have {num_workers}."
-                "Failure to allocate sufficent workers may result in jobs not being processed."
+                f"With {num_processes} queues, you should have >> {min_workers} workers, "
+                "but you only have {num_workers}. "
+                "Failure to allocate sufficent workers may result in jobs not being processed. "
                 "Consider increasing the number of workers, or decreasing the number of redis queues."
             )
     return num_processes

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/launcher.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/launcher.py
@@ -45,13 +45,14 @@ def launch_redis_processes(
 def _get_num_redis_dbs(num_processes: int, num_workers: int) -> int:
     if num_processes == DEFAULT_NUM_REDIS_DBS:
         num_processes = int(math.ceil(num_workers / DEFAULT_WORKERS_PER_REDIS_INSTANCE))
-    elif num_workers <  _expected_sufficient_workers(num_processes):
-        logger.warning(
-            f"With {num_processes} queues, you should have >> {_expected_sufficient_workers(num_processes)} workers,"
-            "but you only have {num_workers}."
-            "Failure to allocate sufficent workers may result in jobs not being processed."
-            "Consider increasing the number of workers, or decreasing the number of redis queues."
-        )
+    else:
+        min_workers = _expected_sufficient_workers(num_processes)
+        if num_workers < min_workers:
+            logger.warning(
+                f"With {num_processes} queues, you should have >> {min_workers} workers, but you only have {num_workers}."
+                "Failure to allocate sufficent workers may result in jobs not being processed."
+                "Consider increasing the number of workers, or decreasing the number of redis queues."
+            )
     return num_processes
 
 
@@ -96,6 +97,7 @@ def _get_random_free_port() -> int:
     port = s.getsockname()[1]
     s.close()
     return port
+
 
 def _expected_sufficient_workers(num_queues) -> int:
     # Rough estimate of the number of workers needed to ensure that each queue gets

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -194,11 +194,10 @@ def main(
     else:
         logger.info(f"Found {len(job_parameters)} jobs to run.")
 
-    num_workers = (
-        extra_args["max_workers"]
-        and min(extra_args["max_workers"], len(job_parameters))
-        or len(job_parameters)
-    )
+    if extra_args["max_workers"]:
+        num_workers = min(extra_args["max_workers"], len(job_parameters))
+    else:
+        num_workers = len(job_parameters)
 
     logger.info("Spinning up Redis DBs and connecting to main process.")
     # Spin up the job & result dbs and get back (hostname, port) pairs for all the dbs.

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -6,10 +6,10 @@ psimulate Runner
 The main process loop for `psimulate` runs.
 
 """
+import math
 from collections import defaultdict
 from pathlib import Path
 from time import sleep, time
-import math
 
 import pandas as pd
 from loguru import logger
@@ -193,7 +193,7 @@ def main(
         return
     else:
         logger.info(f"Found {len(job_parameters)} jobs to run.")
-    
+
     num_workers = (
         extra_args["max_workers"]
         and min(extra_args["max_workers"], len(job_parameters))

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -199,18 +199,6 @@ def main(
         and min(extra_args["max_workers"], len(job_parameters))
         or len(job_parameters)
     )
-    num_queues = len(registry_manager)
-    ## Rough estimate of the number of workers needed to ensure that each queue gets at least
-    ## one worker. cf. https://w.wiki/7bnb
-    expected_sufficient_workers = int(math.ceil(num_queues * (math.log(num_queues) + 0.57)))
-    if num_workers < expected_sufficient_workers:
-        logger.warning(
-            f"With {num_queues} queues, you should have at least {expected_sufficient_workers} workers, but you only have {num_workers}."
-            "Failure to allocate sufficent workers may result in jobs not being processed."
-            "Consider increasing the number of workers, or decreasing the number of redis queues."
-        )
-
-    
 
     logger.info("Spinning up Redis DBs and connecting to main process.")
     # Spin up the job & result dbs and get back (hostname, port) pairs for all the dbs.

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -194,10 +194,9 @@ def main(
     else:
         logger.info(f"Found {len(job_parameters)} jobs to run.")
 
+    num_workers = len(job_parameters)
     if extra_args["max_workers"]:
-        num_workers = min(extra_args["max_workers"], len(job_parameters))
-    else:
-        num_workers = len(job_parameters)
+        num_workers = min(extra_args["max_workers"], num_workers)
 
     logger.info("Spinning up Redis DBs and connecting to main process.")
     # Spin up the job & result dbs and get back (hostname, port) pairs for all the dbs.


### PR DESCRIPTION
##Add Max Workers option to throttle jobs
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
feature
- *JIRA issue*: [MIC-4554](https://jira.ihme.washington.edu/browse/MIC-4554)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Add a click option to set max number of workers/jobs to submit to the cluster.
Since the workers are created in "burst" mode, they will automatically pick up workers from their queue as they finish.

A failure mode is that some care should be taken to ensure that there are many more workers than queues, so that no queue is left entirely empty.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

Tested basic functionality with MNCH:
--max jobs option does throttle number of concurrent jobs
--warning is given if you specify too few workers per queue
--0 input produces an error
--having a very high threshold gives you the default, total number of jobs.
