### PR TITLE
Fix Job Params

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.3.13 - 10/02/23**
+
+ - Bugfixes for psimulate introduced by previous bugfix
+
 **1.3.12 - 09/22/23**
 
  - Bugfixes for psimulate

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -111,20 +111,7 @@ def setup_sim(job_parameters: JobParameters) -> SimulationContext:
     )
 
     configuration.update(
-        {
-            "run_configuration": {
-                "run_id": str(get_current_job().id) + "_" + str(time()),
-                "results_directory": job_parameters.results_path,
-                "run_key": job_parameters.job_specific,
-            },
-            "randomness": {
-                "random_seed": job_parameters.random_seed,
-                "additional_seed": job_parameters.input_draw,
-            },
-            "input_data": {
-                "input_draw_number": job_parameters.input_draw,
-            },
-        },
+        parameter_update_format(job_parameters),
         layer="branch_expanded",
         source="branch_config",
     )
@@ -170,3 +157,20 @@ def do_sim_epilogue(
         )
     )
     logger.remove(perf_log)
+
+
+def parameter_update_format(job_parameters: JobParameters) -> dict:
+    return {
+        "run_configuration": {
+            "run_id": str(get_current_job().id) + "_" + str(time()),
+            "results_directory": job_parameters.results_path,
+            "run_key": job_parameters.job_specific,
+        },
+        "randomness": {
+            "random_seed": job_parameters.random_seed,
+            "additional_seed": job_parameters.input_draw,
+        },
+        "input_data": {
+            "input_draw_number": job_parameters.input_draw,
+        },
+    }

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -128,7 +128,7 @@ def setup_sim(job_parameters: JobParameters) -> SimulationContext:
         layer="branch_expanded",
         source="branch_config",
     )
-
+    job_parameters.branch_configuration.update(configuration.to_dict())
     sim = SimulationContext(job_parameters.model_specification, configuration=configuration)
     logger.info("Simulation configuration:")
     logger.info(str(sim.configuration))

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -1,11 +1,12 @@
-import pytest
-
 from time import time
+
+import pytest
 from vivarium.framework.utilities import collapse_nested_dict
+
 from vivarium_cluster_tools.psimulate.jobs import JobParameters
 from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import (
-    setup_sim,
     parameter_update_format,
+    setup_sim,
 )
 
 

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -3,7 +3,10 @@ import pytest
 from time import time
 from vivarium.framework.utilities import collapse_nested_dict
 from vivarium_cluster_tools.psimulate.jobs import JobParameters
-from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import setup_sim, parameter_update_format
+from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import (
+    setup_sim,
+    parameter_update_format,
+)
 
 
 def test_setup_sim(mocker):
@@ -26,22 +29,19 @@ def test_setup_sim(mocker):
         results_path="~/tmp",
         extras={},
     )
-    
+
     initial_job_params = job_parameters.branch_configuration.copy()
     update_dict = parameter_update_format(job_parameters)
     sim_config = setup_sim(job_parameters).configuration.to_dict()
     job_config = job_parameters.branch_configuration
-    
+
     def compare_dicts(test_dict, ref_dict):
         for k, v in ref_dict.items():
             if isinstance(v, dict):
                 compare_dicts(test_dict[k], v)
             else:
                 assert test_dict[k] == v
-    
+
     for test_dict in [sim_config, job_config]:
         for ref_dict in [initial_job_params, update_dict]:
             compare_dicts(test_dict, ref_dict)
-
-    
-    

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -1,7 +1,9 @@
 import pytest
 
+from time import time
+from vivarium.framework.utilities import collapse_nested_dict
 from vivarium_cluster_tools.psimulate.jobs import JobParameters
-from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import setup_sim
+from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import setup_sim, parameter_update_format
 
 
 def test_setup_sim(mocker):
@@ -9,7 +11,10 @@ def test_setup_sim(mocker):
         "vivarium_cluster_tools.psimulate.worker.vivarium_work_horse.get_current_job",
         return_value=mocker.Mock(id="test_string"),
     )
-
+    mocker.patch(
+        "vivarium_cluster_tools.psimulate.worker.vivarium_work_horse.time",
+        return_value=1337,
+    )
     job_parameters = JobParameters(
         model_specification=None,
         branch_configuration={
@@ -21,7 +26,22 @@ def test_setup_sim(mocker):
         results_path="~/tmp",
         extras={},
     )
-    sim_config = setup_sim(job_parameters).configuration
+    
+    initial_job_params = job_parameters.branch_configuration.copy()
+    update_dict = parameter_update_format(job_parameters)
+    sim_config = setup_sim(job_parameters).configuration.to_dict()
+    job_config = job_parameters.branch_configuration
+    
+    def compare_dicts(test_dict, ref_dict):
+        for k, v in ref_dict.items():
+            if isinstance(v, dict):
+                compare_dicts(test_dict[k], v)
+            else:
+                assert test_dict[k] == v
+    
+    for test_dict in [sim_config, job_config]:
+        for ref_dict in [initial_job_params, update_dict]:
+            compare_dicts(test_dict, ref_dict)
 
-    assert sim_config["time"]["end"]["year"] == 2020
-    assert sim_config["input_data"]["artifact_path"] == "~/vivarium.yaml"
+    
+    

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -36,6 +36,8 @@ def test_setup_sim(mocker):
     sim_config = setup_sim(job_parameters).configuration.to_dict()
     job_config = job_parameters.branch_configuration
 
+    ## Check that for all nested key, value pairs in ref_dict,
+    ## the test dict has that key with the same value.
     def compare_dicts(test_dict, ref_dict):
         for k, v in ref_dict.items():
             if isinstance(v, dict):


### PR DESCRIPTION
## Fix Job Params
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
bugfix
- *JIRA issue*: [MIC-4332](https://jira.ihme.washington.edu/browse/MIC-4332)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
It turns out we are depended on the JobParams object itself having its branch config updated, so updating a copy as a ConfigTree left things out of the results .hdf

It is also not so easy to just use the sim.configuration tree in place of job_parameters, since theres a lot of extra stuff. In the end, i went with a minimal change although this preserves the (somewhat more explicit now) dependence on job parameters being updated. I think it would be a good idea to consider combing through this for a more extensive refactor; i think we could probably streamline this a bit
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
added a bit more test coverage. Tested with MNCH maternal model