### PR TITLE
Remove Python 3.8 from CI and docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11"]
     defaults:
       run:
         shell: bash -le {0}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,7 +5,7 @@ version: 2
 # Configure the python version and environment construction run before
 # docs are built.
 python:
-  version: 3.8
+  version: 3.9
   install:
       # This runs pip install .[docs] from the project root.
     - method: pip

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -195,7 +195,7 @@ texinfo_documents = [
 
 # Other docs we can link to
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/3.8", None),
+    "python": ("https://docs.python.org/", None),
     "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "tables": ("https://www.pytables.org/", None),
     "numpy": ("https://numpy.org/doc/stable/", None),


### PR DESCRIPTION
## Remove Python 3.8 from build.yml
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
CI
- *JIRA issue*: [MIC-4598](https://jira.ihme.washington.edu/browse/MIC-4598)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
PyTables more or less deprecated Python 3.8 in their most recent release, and it's causing our builds to fail. We determined that it is probably best to just follow suit and drop 3.8 from our CI.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
CI passes
