### PR TITLE
--max-workers for restart, expand, and test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,8 @@
 **1.4.3 - 10/25/23**
 
  - Bugfix implement --max-workers option for psimulate restart, expand, and test
+ - Bugfix update default output directory
+ - Update runtime error message if env is different on restart or expand
 
 **1.4.2 - 10/13/23**
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.4.3 - 10/25/23**
+
+ - Bugfix implement --max-workers option for psimulate restart, expand, and test
+
 **1.4.2 - 10/13/23**
 
  - Bugfix checking for max_workers arg

--- a/docs/source/distributed_runner.rst
+++ b/docs/source/distributed_runner.rst
@@ -19,7 +19,7 @@ Very similar to this, ``vivarium-cluster-tools`` includes a command for simulati
 
     psimulate run /path/to/your/model/specification  /path/to/your/branch
 
-By default, output will be saved in ``/share/costeffectiveness/results``. If you want to save the
+By default, output will be saved in ``/mnt/team/simulation_science/costeffectiveness/results``. If you want to save the
 results somewhere else you can specify your output directory as an optional argument
 
 .. code-block:: console

--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -46,6 +46,7 @@ shared_options = [
     cluster.with_project,
     cluster.with_queue_and_max_runtime,
     cluster.with_peak_memory,
+    redis_dbs.with_max_workers,
     redis_dbs.with_redis,
     results.with_no_batch,
     cli_tools.with_verbose_and_pdb,
@@ -80,12 +81,6 @@ shared_options = [
     "created in this directory with the same name as the "
     "configuration file.",
     callback=cli_tools.coerce_to_full_path,
-)
-@click.option(
-    "--max-workers",
-    type=click.IntRange(min=1),
-    help="The maximum number of workers (and therefore jobs) to run concurrently."
-    "If unset, submit all jobs at once and let the cluster schedule them.",
 )
 @cli_tools.pass_shared_options(shared_options)
 def run(
@@ -132,9 +127,10 @@ def run(
             peak_memory=options["peak_memory"],
             max_runtime=options["max_runtime"],
         ),
+        max_workers=options["max_workers"],
         redis_processes=options["redis"],
         no_batch=options["no_batch"],
-        extra_args={"max_workers": options["max_workers"]},
+        extra_args={},
     )
 
 
@@ -168,6 +164,7 @@ def restart(results_root, **options):
             peak_memory=options["peak_memory"],
             max_runtime=options["max_runtime"],
         ),
+        max_workers=options["max_workers"],
         redis_processes=options["redis"],
         no_batch=options["no_batch"],
         extra_args={},
@@ -218,6 +215,7 @@ def expand(results_root, **options):
             peak_memory=options["peak_memory"],
             max_runtime=options["max_runtime"],
         ),
+        max_workers=options["max_workers"],
         redis_processes=options["redis"],
         no_batch=options["no_batch"],
         extra_args={
@@ -261,6 +259,7 @@ def test(test_type, num_workers, result_directory, **options):
             peak_memory=options["peak_memory"],
             max_runtime=options["max_runtime"],
         ),
+        max_workers=options["max_workers"],
         redis_processes=options["redis"],
         no_batch=options["no_batch"],
         extra_args={

--- a/src/vivarium_cluster_tools/psimulate/jobs.py
+++ b/src/vivarium_cluster_tools/psimulate/jobs.py
@@ -65,7 +65,7 @@ def build_job_list(
     number_already_completed = 0
 
     if command in [COMMANDS.run, COMMANDS.restart, COMMANDS.expand]:
-        for (input_draw, random_seed, branch_config) in keyspace:
+        for input_draw, random_seed, branch_config in keyspace:
             parameters = JobParameters(
                 model_specification=str(model_specification_path),
                 branch_configuration=branch_config,

--- a/src/vivarium_cluster_tools/psimulate/paths.py
+++ b/src/vivarium_cluster_tools/psimulate/paths.py
@@ -13,7 +13,7 @@ from vivarium.interface.utilities import get_output_model_name_string
 from vivarium_cluster_tools import utilities as vct_utils
 from vivarium_cluster_tools.psimulate import COMMANDS
 
-DEFAULT_OUTPUT_DIRECTORY = "/share/costeffectiveness/results"
+DEFAULT_OUTPUT_DIRECTORY = "/mnt/team/simulation_science/costeffectiveness/results"
 
 
 class InputPaths(NamedTuple):

--- a/src/vivarium_cluster_tools/psimulate/pip_env.py
+++ b/src/vivarium_cluster_tools/psimulate/pip_env.py
@@ -94,7 +94,8 @@ def _compare_environments(current: Dict, original: Dict) -> None:
     if differences:
         differences = "\n".join(differences)
         raise ValueError(
-            f"Differences found between environment used for original run and current environment. "
-            f"In order to successfully run, you should make a new environment using the requirements.txt "
-            f"file found in the output directory. Differences found as follows: {differences}."
+            "Differences found between environment used for original run and current environment. "
+            "In order to successfully run, you should make a new environment using the requirements.txt "
+            "file found in the output directory (or rename/delete the requirements.txt before running "
+            f"if you know what you're doing).\n\nDifferences found as follows: {differences}."
         )

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/__init__.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/__init__.py
@@ -6,7 +6,10 @@ redis_dbs
 Redis database management.
 
 """
-from vivarium_cluster_tools.psimulate.redis_dbs.cli_options import with_redis
+from vivarium_cluster_tools.psimulate.redis_dbs.cli_options import (
+    with_max_workers,
+    with_redis,
+)
 from vivarium_cluster_tools.psimulate.redis_dbs.launcher import (
     launch_redis_processes as launch,
 )

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/cli_options.py
@@ -22,3 +22,13 @@ with_redis = click.option(
         f"{DEFAULT_WORKERS_PER_REDIS_INSTANCE} workers."
     ),
 )
+
+with_max_workers = click.option(
+    "--max-workers",
+    "-w",
+    type=click.IntRange(min=1),
+    help=(
+        "The maximum number of workers (and therefore jobs) to run "
+        "concurrently. Defaults to the total number of jobs."
+    ),
+)

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
@@ -20,7 +20,6 @@ from rq.registry import FinishedJobRegistry, StartedJobRegistry
 
 
 class QueueManager:
-
     retries_before_fail = 10
     backoff = 30
 

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -6,10 +6,10 @@ psimulate Runner
 The main process loop for `psimulate` runs.
 
 """
-import math
 from collections import defaultdict
 from pathlib import Path
 from time import sleep, time
+from typing import Optional
 
 import pandas as pd
 from loguru import logger
@@ -114,6 +114,7 @@ def main(
     command: str,
     input_paths: paths.InputPaths,
     native_specification: cluster.NativeSpecification,
+    max_workers: Optional[int],
     redis_processes: int,
     no_batch: bool,
     extra_args: dict,
@@ -195,8 +196,8 @@ def main(
         logger.info(f"Found {len(job_parameters)} jobs to run.")
 
     num_workers = len(job_parameters)
-    if extra_args.get("max_workers", None):
-        num_workers = min(extra_args["max_workers"], num_workers)
+    if max_workers:
+        num_workers = min(max_workers, num_workers)
 
     logger.info("Spinning up Redis DBs and connecting to main process.")
     # Spin up the job & result dbs and get back (hostname, port) pairs for all the dbs.


### PR DESCRIPTION
## implement --max-workers option for all psimulate commands
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> implementation
- *JIRA issue*: [MIC-4651](https://jira.ihme.washington.edu/browse/MIC-4651)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Ran `psimulate test` to ensure the logic is correct. Should be identical 
at that point for restart and expand.

