### PR TITLE
Feature/sbachmei/fix default results dir and max workers

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+**1.5.0 - 10/27/23**
+
+ - Remove default results directory for 'psimulate run'
+ - Modify default output directory for 'psimulate test'
+ - Add --max-workers default of 8000
+
 **1.4.3 - 10/25/23**
 
  - Bugfix implement --max-workers option for psimulate restart, expand, and test

--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -75,8 +75,7 @@ shared_options = [
     "--result-directory",
     "-o",
     type=click.Path(file_okay=False),
-    default=paths.DEFAULT_OUTPUT_DIRECTORY,
-    show_default=True,
+    required=True,
     help="The directory to write results to. A folder will be "
     "created in this directory with the same name as the "
     "configuration file.",
@@ -240,7 +239,7 @@ def expand(results_root, **options):
     "--result-directory",
     "-o",
     type=click.Path(file_okay=False),
-    default=f"{paths.DEFAULT_OUTPUT_DIRECTORY}/load_tests",
+    default=paths.DEFAULT_LOAD_TESTS_DIR,
     callback=cli_tools.coerce_to_full_path,
 )
 @cli_tools.pass_shared_options(shared_options)

--- a/src/vivarium_cluster_tools/psimulate/paths.py
+++ b/src/vivarium_cluster_tools/psimulate/paths.py
@@ -13,7 +13,7 @@ from vivarium.interface.utilities import get_output_model_name_string
 from vivarium_cluster_tools import utilities as vct_utils
 from vivarium_cluster_tools.psimulate import COMMANDS
 
-DEFAULT_OUTPUT_DIRECTORY = "/mnt/team/simulation_science/costeffectiveness/results"
+DEFAULT_LOAD_TESTS_DIR = "/mnt/team/simulation_science/priv/engineering/load_tests"
 
 
 class InputPaths(NamedTuple):

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/cli_options.py
@@ -27,6 +27,8 @@ with_max_workers = click.option(
     "--max-workers",
     "-w",
     type=click.IntRange(min=1),
+    default=8000,
+    show_default=True,
     help=(
         "The maximum number of workers (and therefore jobs) to run "
         "concurrently. Defaults to the total number of jobs."


### PR DESCRIPTION
## Remove default results dir; add default max workers
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> other
- *JIRA issue*: na

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
- Removes default results directory for psimulate run
- Modifies defaults output directory for psimulate test
- Adds a --max-workers default of 8000

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tested changes locally
