### PR TITLE
Clean up duplicative per-worker perf logs after creating summary

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.5.2 - 12/29/23**
+
+ - Automatically remove duplicative perf logs after log_summary.csv is created
+
 **1.5.1 - 12/15/23**
 
  - Add logging documentation for psimulate

--- a/src/vivarium_cluster_tools/vipin/perf_report.py
+++ b/src/vivarium_cluster_tools/vipin/perf_report.py
@@ -94,6 +94,13 @@ class PerformanceSummary:
     TELEMETRY_PATTERN = re.compile(r"^{\"host\".+\"job_number\".+}$")
     PERF_LOG_PATTERN = re.compile(r"^perf\.([0-9]+)\.([0-9]+)\.log$")
 
+    def clean_perf_logs(self):
+        """Remove all performance logs from the log_dir (after to_df has been called)"""
+        for log in [
+            f for f in self.log_dir.iterdir() if self.PERF_LOG_PATTERN.fullmatch(f.name)
+        ]:
+            log.unlink()
+
 
 def set_index_scenario_cols(perf_df: pd.DataFrame) -> Tuple[pd.DataFrame, list]:
     """Get the columns useful to index performance data by."""
@@ -211,6 +218,9 @@ def report_performance(
     else:
         out_file = out_file.with_suffix(".csv")
         perf_df.to_csv(out_file)
+
+    # Clean up performance logs
+    perf_summary.clean_perf_logs()
 
     if verbose:
         print_stat_report(perf_df, scenario_cols)


### PR DESCRIPTION
## Clean up duplicative per-worker perf logs after creating summary

### Description
- *Category*: feature
- *JIRA issue*: [MIC-4759](https://jira.ihme.washington.edu/browse/MIC-4759)

### Changes and notes
- Adds a class method to remove perf logs
- Adds call to aforementioned class method after writing the log summary

### Testing
Verified perf logs are gone after short run of MNCH.

