### PR TITLE
add -h --hardware option

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -5,7 +5,7 @@
 <!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
 - *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                    revert, test, release, other/misc -->
-- *JIRA issue*: [MIC-XYZ](https://jira.ihme.washington.edu/browse/MIC-XYZ)
+- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ
 
 ### Changes and notes
 <!-- 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+**1.5.3 - 01/04/24**
+
+ - Implement hardware constraint option for psimulate commands
+ - Make -P/--project a psimulate required option
+
 **1.5.2 - 12/29/23**
 
  - Automatically remove duplicative perf logs after log_summary.csv is created

--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -46,6 +46,7 @@ shared_options = [
     cluster.with_project,
     cluster.with_queue_and_max_runtime,
     cluster.with_peak_memory,
+    cluster.with_hardware,
     redis_dbs.with_max_workers,
     redis_dbs.with_redis,
     results.with_no_batch,
@@ -125,6 +126,7 @@ def run(
             queue=options["queue"],
             peak_memory=options["peak_memory"],
             max_runtime=options["max_runtime"],
+            hardware=options["hardware"],
         ),
         max_workers=options["max_workers"],
         redis_processes=options["redis"],
@@ -162,6 +164,7 @@ def restart(results_root, **options):
             queue=options["queue"],
             peak_memory=options["peak_memory"],
             max_runtime=options["max_runtime"],
+            hardware=options["hardware"],
         ),
         max_workers=options["max_workers"],
         redis_processes=options["redis"],
@@ -180,12 +183,14 @@ def restart(results_root, **options):
     "--add-draws",
     type=int,
     default=0,
+    show_default=True,
     help="The number of input draws to add to a previous run.",
 )
 @click.option(
     "--add-seeds",
     type=int,
     default=0,
+    show_default=True,
     help="The number of random seeds to add to a previous run.",
 )
 @cli_tools.pass_shared_options(shared_options)
@@ -213,6 +218,7 @@ def expand(results_root, **options):
             queue=options["queue"],
             peak_memory=options["peak_memory"],
             max_runtime=options["max_runtime"],
+            hardware=options["hardware"],
         ),
         max_workers=options["max_workers"],
         redis_processes=options["redis"],
@@ -234,12 +240,14 @@ def expand(results_root, **options):
     "-n",
     type=click.INT,
     default=1000,
+    show_default=True,
 )
 @click.option(
     "--result-directory",
     "-o",
     type=click.Path(file_okay=False),
     default=paths.DEFAULT_LOAD_TESTS_DIR,
+    show_default=True,
     callback=cli_tools.coerce_to_full_path,
 )
 @cli_tools.pass_shared_options(shared_options)
@@ -257,6 +265,7 @@ def test(test_type, num_workers, result_directory, **options):
             queue=options["queue"],
             peak_memory=options["peak_memory"],
             max_runtime=options["max_runtime"],
+            hardware=options["hardware"],
         ),
         max_workers=options["max_workers"],
         redis_processes=options["redis"],

--- a/src/vivarium_cluster_tools/psimulate/cluster/__init__.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/__init__.py
@@ -7,6 +7,7 @@ Tools for interacting with the IHME cluster.
 
 """
 from vivarium_cluster_tools.psimulate.cluster.cli_options import (
+    with_hardware,
     with_peak_memory,
     with_project,
     with_queue_and_max_runtime,

--- a/src/vivarium_cluster_tools/psimulate/cluster/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/cli_options.py
@@ -32,8 +32,9 @@ def _validate_and_split_hardware(
     bad_requests = set(hardware) - set(_AVAILABLE_HARDWARE)
     if bad_requests:
         raise click.BadParameter(
-            f"Hardware request(s) {bad_requests} are not supported. "
-            f"Supported hardware requests: {_AVAILABLE_HARDWARE}"
+            f"Hardware request(s) {bad_requests} are not supported.\n"
+            f"Supported hardware requests: {_AVAILABLE_HARDWARE}.\n"
+            "Refer to https://docs.cluster.ihme.washington.edu/#hpc-execution-host-hardware-specifications"
         )
     return hardware
 

--- a/src/vivarium_cluster_tools/psimulate/cluster/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/cli_options.py
@@ -7,9 +7,36 @@ Command line options for configuring the cluster environment in psimulate runs.
 
 """
 
+from typing import List, Optional
+
 import click
 
 _RUNTIME_FORMAT = "hh:mm:ss"
+
+# https://docs.cluster.ihme.washington.edu/#hpc-execution-host-hardware-specifications
+_AVAILABLE_HARDWARE = [
+    "c6320",  # typical
+    "r630",  # high capacity
+    "c6420v1",  # batch 1
+    "c6420v2",  # batch 2
+    "r650",  # high capacity
+    "r650v2",  # high capacity
+    "r650xs",  # high speed
+]
+
+
+def _validate_and_split_hardware(
+    ctx: click.Context, param: click.core.Option, value: Optional[str]
+) -> List[Optional[str]]:
+    hardware = value.split(",") if value else []
+    bad_requests = set(hardware) - set(_AVAILABLE_HARDWARE)
+    if bad_requests:
+        raise click.BadParameter(
+            f"Hardware request(s) {bad_requests} are not supported. "
+            f"Supported hardware requests: {_AVAILABLE_HARDWARE}"
+        )
+    return hardware
+
 
 with_project = click.option(
     "--project",
@@ -22,6 +49,7 @@ with_project = click.option(
         ]
     ),
     default="proj_simscience_prod",
+    show_default=True,
     help="The cluster project under which to run the simulation.",
 )
 
@@ -41,10 +69,25 @@ with_peak_memory = click.option(
     "-m",
     type=int,
     default=3,
+    show_default=True,
     help=(
         "The estimated maximum memory usage in GB of an individual simulate job. "
         "The simulations will be run with this as a limit."
     ),
+)
+
+
+with_hardware = click.option(
+    "--hardware",
+    "-h",
+    help=(
+        "The (comma-separated) specific hardware to run the jobs on. This can be useful to request "
+        "specifically fast nodes ('-h r650xs') vs high capacity nodes ('-h r630,r650,r650v2'). "
+        "Note that the hardware changes on a roughly annual schedule. "
+        f"The currently-supported options are: {_AVAILABLE_HARDWARE}. "
+        "For details, refer to: https://docs.cluster.ihme.washington.edu/#hpc-execution-host-hardware-specifications"
+    ),
+    callback=_validate_and_split_hardware,
 )
 
 
@@ -118,10 +161,10 @@ _with_max_runtime = click.option(
     "-r",
     type=str,
     default="24:00:00",
+    show_default=True,
     help=(
         f"The estimated maximum runtime ({_RUNTIME_FORMAT}) of the simulation jobs. "
-        "By default, the cluster will terminate jobs after 24h regardless of "
-        "queue. The maximum supported runtime is 3 days. Keep in mind that the "
+        "The maximum supported runtime is 3 days. Keep in mind that the "
         "session you are launching from must be able to live at least as long "
         "as the simulation jobs, and that runtimes by node vary wildly."
     ),

--- a/src/vivarium_cluster_tools/psimulate/cluster/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/cli_options.py
@@ -49,8 +49,7 @@ with_project = click.option(
             "proj_csu",
         ]
     ),
-    default="proj_simscience_prod",
-    show_default=True,
+    required=True,
     help="The cluster project under which to run the simulation.",
 )
 

--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -9,7 +9,7 @@ import atexit
 import os
 import shutil
 from pathlib import Path
-from typing import NamedTuple, TextIO
+from typing import List, NamedTuple, Optional, TextIO
 
 from vivarium_cluster_tools.psimulate.environment import ENV_VARIABLES
 from vivarium_cluster_tools.utilities import get_drmaa
@@ -30,6 +30,7 @@ class NativeSpecification(NamedTuple):
     queue: str
     peak_memory: str
     max_runtime: str
+    hardware: List[Optional[str]]
 
     # Class constant
     NUM_THREADS: int = 1
@@ -41,8 +42,9 @@ class NativeSpecification(NamedTuple):
             f"-p {self.queue} "
             f"--mem={self.peak_memory*1024} "
             f"-t {self.max_runtime} "
-            f"-c {self.NUM_THREADS}"
-        )
+            f"-c {self.NUM_THREADS} "
+            f"{'-C ' + '|'.join(self.hardware) if self.hardware else ''}"
+        ).strip()
 
 
 def submit_worker_jobs(

--- a/src/vivarium_cluster_tools/vipin/cli.py
+++ b/src/vivarium_cluster_tools/vipin/cli.py
@@ -26,9 +26,7 @@ from vivarium_cluster_tools.vipin import perf_report
     "Defaults to given logs directory if not given.",
 )
 @click.option(
-    "--hdf/--csv",
-    default=False,
-    help="Choose hdf or csv for output data. Defaults to csv.",
+    "--hdf/--csv", default=False, help="Choose hdf or csv for output data. Defaults to csv."
 )
 @click.option("-v", "verbose", count=True, help="Configure logging verbosity.")
 def vipin(logs_directory, result_directory, hdf, verbose):

--- a/src/vivarium_cluster_tools/vipin/cli.py
+++ b/src/vivarium_cluster_tools/vipin/cli.py
@@ -26,7 +26,10 @@ from vivarium_cluster_tools.vipin import perf_report
     "Defaults to given logs directory if not given.",
 )
 @click.option(
-    "--hdf/--csv", default=False, help="Choose hdf or csv for output data. Defaults to csv."
+    "--hdf/--csv",
+    default=False,
+    show_default=True,
+    help="Choose hdf or csv for output data. Defaults to csv.",
 )
 @click.option("-v", "verbose", count=True, help="Configure logging verbosity.")
 def vipin(logs_directory, result_directory, hdf, verbose):

--- a/src/vivarium_cluster_tools/vipin/cli.py
+++ b/src/vivarium_cluster_tools/vipin/cli.py
@@ -28,7 +28,6 @@ from vivarium_cluster_tools.vipin import perf_report
 @click.option(
     "--hdf/--csv",
     default=False,
-    show_default=True,
     help="Choose hdf or csv for output data. Defaults to csv.",
 )
 @click.option("-v", "verbose", count=True, help="Configure logging verbosity.")


### PR DESCRIPTION
## Add -h/--hardware option to psimulate
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> implementation
- *JIRA issue*: [MIC-4756](https://jira.ihme.washington.edu/browse/MIC-4756)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
There are many ways to implement this -C flag including a simple
comma-separated list as well as boolean strings. I opted to have the
user provide a comma-separated list (e.g. `psimulate --hardware r630,r650xs`)
which then gets converted for the job template to `-C "r630|r650xs"`. I figured
maybe one day we will want to get crazy with logic.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
used `psimulate test` to confirm this is working.

