### PR TITLE
Adjust Queue Logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,6 +106,9 @@ venv.bak/
 # Pycharm project settings
 .idea/
 
+# Vscode project settings
+.vscode/
+
 # Version file
 src/vivarium_cluster_tools/_version.py
 

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
@@ -99,7 +99,6 @@ class QueueManager:
         template = (
             f"Queue {self.name} - Total jobs: {{total}}, % Done: {{done:.2f}}% "
             f"Pending: {{pending}}, Running: {{running}}, Failed: {{failed}}, Successful: {{successful}} "
-            f"Workers: {{workers}}."
         )
         if not (self.completed or self.failed):
             self._logger.info(template.format(**self._status))
@@ -293,7 +292,7 @@ class RegistryManager:
         template = (
             "Queue all - Total jobs: {total}, % Done: {done:.2f}% "
             "Pending: {pending}, Running: {running}, Failed: {failed}, Successful: {successful} "
-            "Active Workers: {workers}, Inactive Workers: {unscheduled}."
+            "Inactive Workers: {unscheduled}."
         )
 
         self._logger.info(template.format(**status))

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
@@ -145,7 +145,9 @@ class QueueManager:
                     + self._status["successful"]
                 )
                 self._status["workers"] = q_workers
-                self._status["done"] = 100 * self._status["successful"] / self._status["total"]
+                self._status["done"] = (
+                    100 * self._status["successful"] / self._status["total"]
+                )
 
                 if len(pending_ids) + len(running_ids) == 0:
                     self._mark_complete()

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
@@ -244,7 +244,12 @@ class QueueManager:
 
 
 class RegistryManager:
-    def __init__(self, redis_processes: List[Tuple[str, int]], submitted_workers: int, num_already_completed: int):
+    def __init__(
+        self,
+        redis_processes: List[Tuple[str, int]],
+        submitted_workers: int,
+        num_already_completed: int,
+    ):
         self._logger = logger.bind(queue="all")
         self._logger.info("Building registries.")
         self._queues = [

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -207,7 +207,7 @@ def main(
         redis_logging_root=output_paths.logging_root,
     )
     # Spin up a unified interface to all the redis databases
-    registry_manager = redis_dbs.RegistryManager(redis_ports, num_jobs_completed)
+    registry_manager = redis_dbs.RegistryManager(redis_ports, num_workers, num_jobs_completed)
     logger.info("Enqueuing jobs on Redis queues.")
     # Distribute all the remaining jobs across the job queues
     # in the redis databases.

--- a/tests/psimulate/redis_dbs/test_registry.py
+++ b/tests/psimulate/redis_dbs/test_registry.py
@@ -9,7 +9,7 @@ def test_allocate_jobs(mocker, num_queues, num_jobs):
     # mock the QueueManager class
     mocker.patch("vivarium_cluster_tools.psimulate.redis_dbs.registry.QueueManager")
     queues = [(f"queue_{i}", i) for i in range(num_queues)]
-    manager = RegistryManager(queues, 0)
+    manager = RegistryManager(queues, num_jobs, 0)
     # create a list of dummy jobs based on a list of integers
     jobs = [{"job": i} for i in range(num_jobs)]
     # make an array of all the jobs in every queue


### PR DESCRIPTION
## Adjust Queue Logging
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
bugfix / documentation
- *JIRA issue*: [MIC-MIC-4650](https://jira.ihme.washington.edu/browse/MIC-MIC-4650)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
From the ticket:

> Overview: The psimulate logger previously has buckets for pending,  running, and workers that come from when we submitted all jobs to slurm at once. Now, the meaning is somewhat different, or at least ambiguous, because "pending" means all queued jobs, not necessarily the set of jobs (or rather, in this case, workers) which have been submitted to slurm but are waiting to receive resources. 

As I imply above, thinking about the "jobs" submitted to the cluster is a sort of category error--it's the _workers_ that are really getting submitted. Ultimately, i thought the most sensible thing would be to leave "pending" as-is, under the understanding that this now means just "idle jobs awating workers". Instead, at the "Queue All" level, I added a listing for "inactive workers", that is, the number of "missing workers" from the number that were intially submitted, that are either a) waiting for cluster resources or b) have completed all jobs in the queue and quit themselves.

I don't think there's a lazy way to disambiguate (a) from (b), you'd need to pull information from outside of the registry--and I figured the two situations can be resolved by context (one happens mostly at the beginning of the sim, and one happens mostly at the end).

>Also, "running" and "workers" should effectively be the same, unless rq.Worker.all also counts workers in the queue that are not performing a job (but in that case they should soon quit?)

I too out "workers", assuming the same information is given by "running"


>Also consider renaming "Finished" to "Successful" or "Completed"

I renamed this job status (but not the underlying FinishedQueue) to Successful for the purposes of logging.

I also changed some log info statements to debug which IMO deserve it
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
Tested against nutrition optimization, but I am not actually getting allocated any workers atm
