### PR TITLE
Mic 4612/env restart

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.5.6 - 02/27/24**
+
+ - Give user option to continue psimulate restart if environment has changed
+
 **1.5.5 - 02/12/24**
 
  - Add central performance logging and testing

--- a/src/vivarium_cluster_tools/psimulate/pip_env.py
+++ b/src/vivarium_cluster_tools/psimulate/pip_env.py
@@ -96,7 +96,7 @@ def _compare_environments(current: Dict, original: Dict) -> None:
         differences = "\n".join(differences)
         logger.info(
             "Differences found between current environment and original environment used for "
-            " this run. \n\nDifferences found are as follows: {differences}. Would you like to proceed?"
+            f" this run. \n\nDifferences found are as follows: {differences}. Would you like to proceed?"
         )
         click.confirm(
             "Would you like to proceed psimulate restart with the new environment?",

--- a/src/vivarium_cluster_tools/psimulate/pip_env.py
+++ b/src/vivarium_cluster_tools/psimulate/pip_env.py
@@ -11,6 +11,7 @@ import subprocess
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+import click
 from loguru import logger
 
 
@@ -93,9 +94,11 @@ def _compare_environments(current: Dict, original: Dict) -> None:
 
     if differences:
         differences = "\n".join(differences)
-        raise ValueError(
-            "Differences found between environment used for original run and current environment. "
-            "In order to successfully run, you should make a new environment using the requirements.txt "
-            "file found in the output directory (or rename/delete the requirements.txt before running "
-            f"if you know what you're doing).\n\nDifferences found as follows: {differences}."
+        logger.info(
+            "Differences found between current environment and original environment used for "
+            " this run. \n\nDifferences found are as follows: {differences}. Would you like to proceed?"
+        )
+        click.confirm(
+            "Would you like to proceed psimulate restart with the new environment?",
+            abort=True,
         )


### PR DESCRIPTION
## Mic-4612/env-restart

### Gives user the ability to choose whether or not to continue psimulate restart if the environment is different from the original run.
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4612

### Changes and notes
-Gives user the option to continue a restart if the environment has changed from the original run

### Testing
Was able to successfully continue a restart or abort a restart.

