### PR TITLE
Mic-4920/draw-max-value-500

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.6.0 - 03/12/24**
+
+ - Limit max number of draws to 500.
+
 **1.5.6 - 02/27/24**
 
  - Give user option to continue psimulate restart if environment has changed

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -136,7 +136,7 @@ def calculate_input_draws(
         existing draw numbers.
 
     """
-    max_draw_count = 1000
+    max_draw_count = 500
     if input_draw_count > max_draw_count:
         raise ValueError(f"Input draw count must be less than {max_draw_count}.")
 

--- a/src/vivarium_cluster_tools/psimulate/branches.py
+++ b/src/vivarium_cluster_tools/psimulate/branches.py
@@ -16,6 +16,8 @@ from vivarium.framework.utilities import collapse_nested_dict
 
 from vivarium_cluster_tools.psimulate.model_specification import FULL_ARTIFACT_PATH_KEY
 
+NUMBER_OF_DRAWS = 500
+
 
 class Keyspace:
     """A representation of a collection of simulation configurations."""
@@ -136,7 +138,7 @@ def calculate_input_draws(
         existing draw numbers.
 
     """
-    max_draw_count = 500
+    max_draw_count = NUMBER_OF_DRAWS
     if input_draw_count > max_draw_count:
         raise ValueError(f"Input draw count must be less than {max_draw_count}.")
 


### PR DESCRIPTION
## Mic-4920/draw-max-value-500

### Limits the max value of draw for keyspace to 499 for GBD 2021 updates
- *Category*: Bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-4920

### Changes and notes
-updates max draw count to 500 to make possible max draw value 499 for new GBD data

### Testing
Successfully ran a parallel sim with no failures.

