### PR TITLE
update psimulate for new results processing

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -10,6 +10,7 @@ Command line interface for `psimulate`.
    :show-nested:
 
 """
+
 from pathlib import Path
 from typing import Optional
 
@@ -87,7 +88,7 @@ def run(
     model_specification: Path,
     branch_configuration: Path,
     artifact_path: Optional[Path],
-    result_directory: Optional[Path],
+    result_directory: Path,
     **options,
 ) -> None:
     """Run a parallel simulation.
@@ -262,15 +263,19 @@ def test(test_type, num_workers, result_directory, **options):
     peak_memory_msg = (
         f"Manually overriding the peak memory request '{test_type}' test to {peak_memory}GB."
     )
-    logger.warning(peak_memory_msg) if options[
-        "peak_memory"
-    ] != cluster.PEAK_MEMORY_DEFAULT else logger.info(peak_memory_msg)
+    (
+        logger.warning(peak_memory_msg)
+        if options["peak_memory"] != cluster.PEAK_MEMORY_DEFAULT
+        else logger.info(peak_memory_msg)
+    )
     max_runtime_msg = (
         f"Manually overriding the max runtime request '{test_type}' test to {max_runtime}."
     )
-    logger.warning(max_runtime_msg) if options[
-        "max_runtime"
-    ] != cluster.MAX_RUNTIME_DEFAULT else logger.info(max_runtime_msg)
+    (
+        logger.warning(max_runtime_msg)
+        if options["max_runtime"] != cluster.MAX_RUNTIME_DEFAULT
+        else logger.info(max_runtime_msg)
+    )
     options["peak_memory"] = peak_memory
     options["max_runtime"] = max_runtime
 

--- a/src/vivarium_cluster_tools/psimulate/model_specification.py
+++ b/src/vivarium_cluster_tools/psimulate/model_specification.py
@@ -11,7 +11,7 @@ from typing import Optional
 
 import yaml
 from layered_config_tree import LayeredConfigTree
-from layered_config_tree.exceptions import ConfigurationError
+from layered_config_tree.exceptions import ConfigurationError, ConfigurationKeyError
 from loguru import logger
 from vivarium.framework.artifact import parse_artifact_path_config
 from vivarium.framework.configuration import build_model_specification

--- a/src/vivarium_cluster_tools/psimulate/paths.py
+++ b/src/vivarium_cluster_tools/psimulate/paths.py
@@ -4,6 +4,7 @@ File Path Management
 ====================
 
 """
+
 from datetime import datetime
 from fnmatch import fnmatch
 from pathlib import Path
@@ -69,7 +70,8 @@ class OutputPaths(NamedTuple):
     branches: Path
 
     # outputs
-    results: Path
+    finished_sim_metadata: Path
+    results_dir: Path
 
     # will not be reliable if we parallelized across artifacts
     @property
@@ -142,11 +144,13 @@ class OutputPaths(NamedTuple):
             model_specification=output_directory / "model_specification.yaml",
             keyspace=output_directory / "keyspace.yaml",
             branches=output_directory / "branches.yaml",
-            results=output_directory / "output.hdf",
+            finished_sim_metadata=output_directory / "finished_sim_metadata.csv",
+            results_dir=output_directory / "results",
         )
         return output_paths
 
     def touch(self) -> None:
-        vct_utils.mkdir(self.root, exists_ok=True, parents=True)
-        for d in [self.logging_root, self.cluster_logging_root, self.worker_logging_root]:
-            vct_utils.mkdir(d, parents=True)
+        for dir in [self.root, self.results_dir]:
+            vct_utils.mkdir(dir, exists_ok=True, parents=True)
+        for dir in [self.logging_root, self.cluster_logging_root, self.worker_logging_root]:
+            vct_utils.mkdir(dir, parents=True)

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
@@ -6,7 +6,7 @@ Redis Queue and Registry Management
 Unified interface to multiple Redis Databases.
 
 """
-import math
+
 import random
 import time
 from collections import defaultdict
@@ -94,7 +94,7 @@ class QueueManager:
         )
         return results
 
-    def update_and_report(self) -> Dict[str, int]:
+    def update_and_report(self) -> Dict[str, Union[int, float]]:
         self._update_status()
         template = (
             f"Queue {self.name} - Total jobs: {{total}}, % Done: {{done:.2f}}% "
@@ -282,7 +282,7 @@ class RegistryManager:
         return results
 
     def update_and_report(self) -> Dict[str, Union[int, float]]:
-        status = defaultdict(int)
+        status: Dict[str, Union[int, float]] = defaultdict(int)
         for queue in self._queues:
             queue_status = queue.update_and_report()
             for k, v in queue_status.items():

--- a/src/vivarium_cluster_tools/psimulate/results/processing.py
+++ b/src/vivarium_cluster_tools/psimulate/results/processing.py
@@ -58,9 +58,8 @@ def _concat_metadata(
     # Skips all the pandas index checking because columns are in the same order.
     start = time.time()
 
-    to_concat = [df.reset_index(drop=True) for df in new_metadata]
-    if not old_metadata.empty:
-        to_concat += [old_metadata.reset_index(drop=True)]
+    to_concat_old = [old_metadata.reset_index(drop=True)] if not old_metadata.empty else []
+    to_concat = to_concat_old + [df.reset_index(drop=True) for df in new_metadata]
 
     updated = _concat_preserve_types(to_concat)
 
@@ -77,15 +76,15 @@ def _concat_results(
     results = {}
     metrics = {key for new in new_results for key in new.keys()}
     for metric in metrics:
-        to_concat = [
+        to_concat_old = (
+            [old_results[metric].reset_index(drop=True)] if metric in old_results else []
+        )
+        to_concat = to_concat_old + [
             df.reset_index(drop=True)
             for result in new_results
             for met, df in result.items()
             if met == metric
         ]
-
-        if metric in old_results:
-            to_concat += [old_results[metric].reset_index(drop=True)]
 
         results[metric] = _concat_preserve_types(to_concat)
 

--- a/src/vivarium_cluster_tools/psimulate/results/processing.py
+++ b/src/vivarium_cluster_tools/psimulate/results/processing.py
@@ -6,70 +6,122 @@ Results Processing
 Tools for processing and writing results.
 
 """
+
 import time
 from pathlib import Path
-from typing import List, Tuple, Union
+from typing import Dict, List, Tuple
 
 import numpy as np
 import pandas as pd
 from loguru import logger
 
 from vivarium_cluster_tools import utilities as vct_utils
+from vivarium_cluster_tools.psimulate.paths import OutputPaths
 
 
 def write_results_batch(
-    output_directory: Path,
-    written_results: pd.DataFrame,
-    unwritten_results: List[pd.DataFrame],
+    output_paths: OutputPaths,
+    existing_metadata: pd.DataFrame,
+    existing_results: Dict[str, pd.DataFrame],
+    unwritten_metadata: List[pd.DataFrame],
+    unwritten_results: List[Dict[str, pd.DataFrame]],
     batch_size: int = 50,
-) -> Tuple[pd.DataFrame, List[pd.DataFrame]]:
+) -> Tuple[
+    pd.DataFrame, List[pd.DataFrame], Dict[str, pd.DataFrame], List[Dict[str, pd.DataFrame]]
+]:
+    """Write batch of results and finished simulation metadata to disk."""
+    logger.info(f"Writing batch of {batch_size} results.")
+    new_metadata_to_write, unwritten_metadata = (
+        unwritten_metadata[:batch_size],
+        unwritten_metadata[batch_size:],
+    )
     new_results_to_write, unwritten_results = (
         unwritten_results[:batch_size],
         unwritten_results[batch_size:],
     )
-    results_to_write = _concat_results(written_results, new_results_to_write)
+    metadata_to_write = _concat_metadata(existing_metadata, new_metadata_to_write)
+    results_to_write = _concat_results(existing_results, new_results_to_write)
 
     start = time.time()
-    _safe_write_results(results_to_write, output_directory / "output.hdf")
+    # write out updated metadata and results
+    for metric, df in results_to_write.items():
+        _safe_write(df, output_paths.results_dir / f"{metric}.parquet")
+    _safe_write(metadata_to_write, output_paths.finished_sim_metadata)
     end = time.time()
-    logger.info(f"Updated output.hdf in {end - start:.4f}s.")
-    return results_to_write, unwritten_results
+    logger.info(f"Updated results in {end - start:.4f}s.")
+    return metadata_to_write, unwritten_metadata, results_to_write, unwritten_results
 
 
-def _concat_results(
-    old_results: pd.DataFrame, new_results: List[pd.DataFrame]
-) -> pd.DataFrame:
+def _concat_metadata(old: pd.DataFrame, new: List[pd.DataFrame]) -> pd.DataFrame:
     # Skips all the pandas index checking because columns are in the same order.
     start = time.time()
 
-    to_concat = [d.reset_index(drop=True) for d in new_results]
-    if not old_results.empty:
-        to_concat += [old_results.reset_index(drop=True)]
+    to_concat = [df.reset_index(drop=True) for df in new]
+    if not old.empty:
+        to_concat += [old.reset_index(drop=True)]
 
-    results = _concat_preserve_types(to_concat)
+    updated = _concat_preserve_types(to_concat)
 
     end = time.time()
-    logger.info(f"Concatenated {len(new_results)} results in {end - start:.2f}s.")
+    logger.info(f"Concatenated {len(new)} metadata in {end - start:.2f}s.")
+    return updated
+
+
+def _concat_results(
+    old: Dict[str, pd.DataFrame], new: List[Dict[str, pd.DataFrame]]
+) -> Dict[str, pd.DataFrame]:
+    # Skips all the pandas index checking because columns are in the same order.
+    start = time.time()
+    results = {}
+    metrics = {key for new_results in new for key in new_results.keys()}
+    for metric in metrics:
+        to_concat = [
+            df.reset_index(drop=True)
+            for result in new
+            for met, df in result.items()
+            if met == metric
+        ]
+
+        if metric in old:
+            to_concat += [old[metric].reset_index(drop=True)]
+
+        results[metric] = _concat_preserve_types(to_concat)
+
+    end = time.time()
+    logger.info(f"Concatenated {len(new)} results in {end - start:.2f}s.")
     return results
 
 
 def _concat_preserve_types(df_list: List[pd.DataFrame]) -> pd.DataFrame:
     """Concatenation preserves all ``numpy`` dtypes but does not preserve any
     pandas specific dtypes (e.g., categories become objects."""
-    dtypes = df_list[0].dtypes
+    # We assume that all dataframes in the list have identical dtypes to the first
+    # Also, we convert dtypes to their string representations to avoid comparison
+    # issues (especially with CategoricalDtype)
+    col_order = df_list[0].columns
+    dtypes = df_list[0].dtypes.astype(str)
     columns_by_dtype = [list(dtype_group.index) for _, dtype_group in dtypes.groupby(dtypes)]
 
     splits = []
     for columns in columns_by_dtype:
+        original_dtypes = {col: df_list[0][col].dtype for col in columns}
         slices = [df.filter(columns) for df in df_list]
-        splits.append(pd.DataFrame(data=np.concatenate(slices), columns=columns))
-    return pd.concat(splits, axis=1)
+        slice_df = pd.DataFrame(data=np.concatenate(slices), columns=columns)
+        for col, dtype in original_dtypes.items():
+            slice_df[col] = slice_df[col].astype(dtype)
+        splits.append(slice_df)
+    return pd.concat(splits, axis=1)[col_order]
 
 
 @vct_utils.backoff_and_retry(backoff_seconds=30, num_retries=3, log_function=logger.warning)
-def _safe_write_results(results: pd.DataFrame, output_path: Union[str, Path]) -> None:
-    # Writing to a hdf over and over balloons the file size so
+def _safe_write(results: pd.DataFrame, output_path: Path) -> None:
+    # Writing to some file types over and over balloons the file size so
     # write to new file and move it over to avoid
     temp_output_path = output_path.with_name(output_path.name + "update")
-    results.to_hdf(temp_output_path, "data")
+    if output_path.suffix == ".parquet":
+        results.to_parquet(temp_output_path)
+    elif output_path.suffix == ".csv":
+        results.to_csv(temp_output_path, index=False)
+    else:
+        raise NotImplementedError(f"Writing to {output_path.suffix} is not supported.")
     temp_output_path.replace(output_path)

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -56,12 +56,6 @@ def process_job_results(
             for metadata, results in registry_manager.get_results():
                 unwritten_metadata.append(metadata)
                 unwritten_results.append(results)
-                if len(unwritten_results) != len(unwritten_metadata):
-                    raise ValueError(
-                        f"Unwritten metadata and results are out of sync:\n"
-                        f"Metadata len ({len(unwritten_metadata)}) != results len "
-                        f"({len(unwritten_results)})"
-                    )
 
             if len(unwritten_results) > batch_size:
                 (

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -6,10 +6,11 @@ psimulate Runner
 The main process loop for `psimulate` runs.
 
 """
+
 from collections import defaultdict
 from pathlib import Path
 from time import sleep, time
-from typing import Optional
+from typing import Dict, Optional, Union
 
 import pandas as pd
 from loguru import logger
@@ -24,9 +25,9 @@ from vivarium_cluster_tools.psimulate import (
     paths,
     pip_env,
     redis_dbs,
-    results,
-    worker,
 )
+from vivarium_cluster_tools.psimulate import results as psim_results
+from vivarium_cluster_tools.psimulate import worker
 from vivarium_cluster_tools.psimulate.paths import OutputPaths
 from vivarium_cluster_tools.psimulate.performance_logger import (
     append_perf_data_to_central_logs,
@@ -36,26 +37,43 @@ from vivarium_cluster_tools.vipin.perf_report import report_performance
 
 def process_job_results(
     registry_manager: redis_dbs.RegistryManager,
-    existing_outputs: pd.DataFrame,
-    output_directory: Path,
+    existing_metadata: pd.DataFrame,
+    existing_results: Dict[str, pd.DataFrame],
+    output_paths: OutputPaths,
     no_batch: bool,
-) -> defaultdict:
-    written_results = existing_outputs
+) -> Dict[str, Union[int, float]]:
+
+    unwritten_metadata = []
     unwritten_results = []
     batch_size = 0 if no_batch else 200
-    status = defaultdict(int)
+    status: Dict[str, Union[int, float]] = defaultdict(int)
 
     logger.info("Entering main processing loop.")
     start_time = time()
     try:
         while registry_manager.jobs_to_finish:
             sleep(5)
-            unwritten_results.extend(registry_manager.get_results())
+            for metadata, results in registry_manager.get_results():
+                unwritten_metadata.append(metadata)
+                unwritten_results.append(results)
+                if len(unwritten_results) != len(unwritten_metadata):
+                    raise ValueError(
+                        f"Unwritten metadata and results are out of sync:\n"
+                        f"Metadata len ({len(unwritten_metadata)}) != results len "
+                        f"({len(unwritten_results)})"
+                    )
 
             if len(unwritten_results) > batch_size:
-                written_results, unwritten_results = results.write_results_batch(
-                    output_directory,
-                    written_results,
+                (
+                    existing_metadata,
+                    unwritten_metadata,
+                    existing_results,
+                    unwritten_results,
+                ) = psim_results.write_results_batch(
+                    output_paths,
+                    existing_metadata,
+                    existing_results,
+                    unwritten_metadata,
                     unwritten_results,
                     batch_size,
                 )
@@ -66,37 +84,55 @@ def process_job_results(
     finally:
         batch_size = 500
         while unwritten_results:
-            written_results, unwritten_results = results.write_results_batch(
-                output_directory,
-                written_results,
+            (
+                existing_metadata,
+                unwritten_metadata,
+                existing_results,
+                unwritten_results,
+            ) = psim_results.write_results_batch(
+                output_paths,
+                existing_metadata,
+                existing_results,
+                unwritten_metadata,
                 unwritten_results,
                 batch_size=batch_size,
             )
             logger.info(f"Unwritten results: {len(unwritten_results)}")
             logger.info(f"Elapsed time: {(time() - start_time) / 60:.1f} minutes.")
-        return status
+
+    return status
 
 
-def load_existing_outputs(result_path: Path, restart: bool) -> pd.DataFrame:
+def load_existing_output_metadata(result_path: Path, restart: bool) -> pd.DataFrame:
     try:
-        existing_outputs = pd.read_hdf(result_path)
+        existing_output_metadata = pd.read_csv(result_path)
     except FileNotFoundError:
-        existing_outputs = pd.DataFrame()
+        existing_output_metadata = pd.DataFrame()
     assert (
-        existing_outputs.empty or restart
+        existing_output_metadata.empty or restart
     ), "How do you have existing outputs on an initial run?"
-    return existing_outputs
+    return existing_output_metadata
+
+
+def load_existing_results(result_path: Path, restart: bool) -> Dict[str, pd.DataFrame]:
+    filepaths = list(result_path.glob("*.parquet"))
+    results = {filepath.stem: pd.read_parquet(filepath) for filepath in filepaths}
+    if results and not restart:
+        raise RuntimeError(
+            f"This is an initial run but results aready exist at {result_path}"
+        )
+    return results
 
 
 def report_initial_status(
-    num_jobs_completed: int, existing_outputs: pd.DataFrame, keyspace: branches.Keyspace
+    num_jobs_completed: int, finished_sim_metadata: pd.DataFrame, total_num_jobs: int
 ) -> None:
     if num_jobs_completed:
         logger.info(
-            f"{num_jobs_completed} of {len(keyspace)} jobs completed in previous run."
+            f"{num_jobs_completed} of {total_num_jobs} jobs completed in previous run."
         )
-    if num_jobs_completed != len(existing_outputs):
-        extra_jobs_completed = num_jobs_completed - len(existing_outputs)
+    if num_jobs_completed != len(finished_sim_metadata):
+        extra_jobs_completed = num_jobs_completed - len(finished_sim_metadata)
         logger.warning(
             f"There are {extra_jobs_completed} jobs from the previous run which would not have been created "
             "with the configuration saved with the run. That either means that code "
@@ -167,6 +203,7 @@ def main(
     # a cartesian product representation of the parameter space and
     # branches is a flat representation with the product expanded out.
     keyspace.persist(output_paths.keyspace, output_paths.branches)
+    total_num_jobs = len(keyspace)
 
     # Parse the model specification and resolve the artifact path
     # and then write to the output directory.
@@ -182,8 +219,8 @@ def main(
 
     logger.info("Loading existing outputs if present.")
     # Load in any existing partial outputs if present.
-    existing_outputs = load_existing_outputs(
-        result_path=output_paths.results,
+    finished_sim_metadata = load_existing_output_metadata(
+        result_path=output_paths.finished_sim_metadata,
         restart=command in [COMMANDS.restart, COMMANDS.expand],
     )
 
@@ -195,11 +232,11 @@ def main(
         model_specification_path=output_paths.model_specification,
         output_root=output_paths.root,
         keyspace=keyspace,
-        existing_outputs=existing_outputs,
+        finished_sim_metadata=finished_sim_metadata,
         extras=extra_args,
     )
     # Let the user know if something is fishy at this point.
-    report_initial_status(num_jobs_completed, existing_outputs, keyspace)
+    report_initial_status(num_jobs_completed, finished_sim_metadata, total_num_jobs)
     if len(job_parameters) == 0:
         logger.info("No jobs to run, exiting.")
         return
@@ -259,10 +296,15 @@ def main(
     # Enter the main monitoring and processing loop, which will check on
     # all the queues periodically, report status updates, and gather
     # and write results when they are available.
+    existing_results = load_existing_results(
+        result_path=output_paths.results_dir,
+        restart=command in [COMMANDS.restart, COMMANDS.expand],
+    )
     status = process_job_results(
         registry_manager=registry_manager,
-        existing_outputs=existing_outputs,
-        output_directory=output_paths.root,
+        existing_metadata=finished_sim_metadata,
+        existing_results=existing_results,
+        output_paths=output_paths,
         no_batch=no_batch,
     )
 
@@ -277,6 +319,8 @@ def main(
         )
 
     logger.info(
-        f"{status['finished']} of {status['total']} jobs completed successfully. "
-        f"Results written to: {str(output_paths.root)}"
+        f"{status['successful'] - num_jobs_completed} of {status['total']} jobs "
+        f"completed successfully from this {command}.\n"
+        f"({status['successful']} of {total_num_jobs} total jobs completed successfully overall)\n"
+        f"Results written to: {str(output_paths.results_dir)}"
     )

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -97,11 +97,7 @@ def work_horse(job_parameters: dict) -> Tuple[pd.DataFrame, Dict[str, pd.DataFra
 
         results = sim.get_results()  # Dict[measure, results dataframe]
 
-        idx = pd.MultiIndex.from_tuples(
-            [(job_parameters.input_draw, job_parameters.random_seed)],
-            names=["input_draw_number", "random_seed"],
-        )
-        finished_results_metadata = pd.DataFrame(index=idx)
+        finished_results_metadata = pd.DataFrame()
         for key, val in collapse_nested_dict(job_parameters.branch_configuration):
             for _metric, df in results.items():
                 finished_results_metadata[key] = val

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -97,11 +97,11 @@ def work_horse(job_parameters: dict) -> Tuple[pd.DataFrame, Dict[str, pd.DataFra
 
         results = sim.get_results()  # Dict[measure, results dataframe]
 
-        finished_results_metadata = pd.DataFrame()
+        finished_results_metadata = pd.DataFrame(index=[0])
         for key, val in collapse_nested_dict(job_parameters.branch_configuration):
             for _metric, df in results.items():
-                finished_results_metadata[key] = val
                 df[key] = val
+            finished_results_metadata[key] = val
         return finished_results_metadata, results
 
     except Exception:

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -12,6 +12,7 @@ import math
 from pathlib import Path
 from time import time
 from traceback import format_exc
+from typing import Dict, Tuple, Union
 
 import pandas as pd
 from layered_config_tree import LayeredConfigTree
@@ -27,7 +28,16 @@ from vivarium_cluster_tools.vipin.perf_counters import CounterSnapshot
 VIVARIUM_WORK_HORSE_IMPORT_PATH = f"{__name__}.work_horse"
 
 
-def work_horse(job_parameters: dict) -> pd.DataFrame:
+class ParallelSimulationContext(SimulationContext):
+    """Identical to SimulationContext except that it does not write out the
+    results to disk in order to allow them to be batch-written.
+    """
+
+    def _write_results(self):
+        pass
+
+
+def work_horse(job_parameters: dict) -> Tuple[pd.DataFrame, Dict[str, pd.DataFrame]]:
     node = f"{ENV_VARIABLES.HOSTNAME.value}"
     job = f"{ENV_VARIABLES.JOB_ID.value}:{ENV_VARIABLES.TASK_ID.value}"
 
@@ -80,20 +90,23 @@ def work_horse(job_parameters: dict) -> pd.DataFrame:
         logger.info(f'Average step length was {exec_time["step_mean_seconds"]:.3f} seconds.')
 
         sim.finalize()
-        metrics = sim.report(print_results=False)
+        sim.report(print_results=False)
         event["end"] = time()
         end_snapshot = CounterSnapshot()
-
         do_sim_epilogue(start_snapshot, end_snapshot, event, exec_time, job_parameters)
+
+        results = sim.get_results()  # Dict[measure, results dataframe]
 
         idx = pd.MultiIndex.from_tuples(
             [(job_parameters.input_draw, job_parameters.random_seed)],
             names=["input_draw_number", "random_seed"],
         )
-        output_metrics = pd.DataFrame(metrics, index=idx)
-        for k, v in collapse_nested_dict(job_parameters.branch_configuration):
-            output_metrics[k] = v
-        return output_metrics
+        finished_results_metadata = pd.DataFrame(index=idx)
+        for key, val in collapse_nested_dict(job_parameters.branch_configuration):
+            for _metric, df in results.items():
+                finished_results_metadata[key] = val
+                df[key] = val
+        return finished_results_metadata, results
 
     except Exception:
         logger.exception("Unhandled exception in worker")
@@ -105,7 +118,7 @@ def work_horse(job_parameters: dict) -> pd.DataFrame:
         logger.info(f"Exiting job: {job_parameters}")
 
 
-def setup_sim(job_parameters: JobParameters) -> SimulationContext:
+def setup_sim(job_parameters: JobParameters) -> ParallelSimulationContext:
     """Set up a simulation context with the branch/job-specific configuration parameters."""
     configuration = LayeredConfigTree(
         job_parameters.branch_configuration, layers=["branch_base", "branch_expanded"]
@@ -117,7 +130,9 @@ def setup_sim(job_parameters: JobParameters) -> SimulationContext:
         source="branch_config",
     )
     job_parameters.branch_configuration.update(configuration.to_dict())
-    sim = SimulationContext(job_parameters.model_specification, configuration=configuration)
+    sim = ParallelSimulationContext(
+        job_parameters.model_specification, configuration=configuration
+    )
     logger.info("Simulation configuration:")
     logger.info(str(sim.configuration))
 
@@ -160,7 +175,9 @@ def do_sim_epilogue(
     logger.remove(perf_log)
 
 
-def parameter_update_format(job_parameters: JobParameters) -> dict:
+def parameter_update_format(
+    job_parameters: JobParameters,
+) -> Dict[str, Dict[str, Union[str, int, dict]]]:
     return {
         "run_configuration": {
             "run_id": str(get_current_job().id) + "_" + str(time()),
@@ -169,7 +186,7 @@ def parameter_update_format(job_parameters: JobParameters) -> dict:
         },
         "randomness": {
             "random_seed": job_parameters.random_seed,
-            "additional_seed": job_parameters.input_draw,
+            "additional_seed": job_parameters.input_draw,  # <- FIXME: is this a typo?
         },
         "input_data": {
             "input_draw_number": job_parameters.input_draw,

--- a/src/vivarium_cluster_tools/utilities.py
+++ b/src/vivarium_cluster_tools/utilities.py
@@ -6,6 +6,7 @@ vivarium_cluster_tools Utilities
 Making directories is hard.
 
 """
+
 import functools
 import os
 import socket
@@ -90,7 +91,7 @@ def backoff_and_retry(
                     break
                 except Exception as e:
                     log_function(
-                        f"Error trying to write results to hdf, retries remaining {retries}"
+                        f"Error trying to write results, retries remaining {retries}"
                     )
                     time.sleep(backoff_seconds)
                     retries -= 1

--- a/tests/psimulate/results/test_processing.py
+++ b/tests/psimulate/results/test_processing.py
@@ -2,8 +2,8 @@ import pandas as pd
 import pytest
 
 from vivarium_cluster_tools.psimulate.results.processing import (
+    _concat_metadata,
     _concat_preserve_types,
-    _concat_results,
 )
 
 
@@ -66,7 +66,7 @@ def test_concat_results(data_types):
     old["input_draw"] = old["random_seed"] = 0.0
     new["input_draw"] = new["random_seed"] = 1.0
 
-    combined = _concat_results(old, [new])
+    combined = _concat_metadata(old, [new])
 
     expected_dtypes = old.dtypes
 
@@ -79,6 +79,6 @@ def test_concat_results(data_types):
     assert combined.dtypes.sort_index().equals(expected_dtypes.sort_index())
 
     # now no existing results
-    no_old_combined = _concat_results(pd.DataFrame(), [new, old])
+    no_old_combined = _concat_metadata(pd.DataFrame(), [new, old])
 
     assert no_old_combined.equals(combined)

--- a/tests/psimulate/results/test_processing.py
+++ b/tests/psimulate/results/test_processing.py
@@ -73,12 +73,12 @@ def test_concat_results(data_types):
     expected_shape = (old.shape[0] + new.shape[0], old.shape[1])
 
     for c in old:
-        assert (combined[c] == pd.concat([new[c], old[c]]).reset_index(drop=True)).all()
+        assert (combined[c] == pd.concat([old[c], new[c]]).reset_index(drop=True)).all()
 
     assert combined.shape == expected_shape
     assert combined.dtypes.sort_index().equals(expected_dtypes.sort_index())
 
     # now no existing results
-    no_old_combined = _concat_metadata(pd.DataFrame(), [new, old])
+    no_old_combined = _concat_metadata(pd.DataFrame(), [old, new])
 
     assert no_old_combined.equals(combined)

--- a/tests/psimulate/results/test_processing.py
+++ b/tests/psimulate/results/test_processing.py
@@ -1,9 +1,13 @@
+from pathlib import Path
+
 import pandas as pd
 import pytest
 
+from vivarium_cluster_tools.psimulate.paths import OutputPaths
 from vivarium_cluster_tools.psimulate.results.processing import (
     _concat_metadata,
     _concat_preserve_types,
+    write_results_batch,
 )
 
 
@@ -82,3 +86,80 @@ def test_concat_results(data_types):
     no_old_combined = _concat_metadata(pd.DataFrame(), [old, new])
 
     assert no_old_combined.equals(combined)
+
+
+def test_write_results_batch(tmp_path):
+    output_paths = OutputPaths.from_entry_point_args(
+        command="foo",
+        input_artifact_path=Path("some/artifact/path"),
+        result_directory=tmp_path,
+        input_model_spec_path=Path("some/model/spec/path"),
+    )
+    output_paths.results_dir.mkdir()
+
+    # create and save out already-existing metadata file and results
+    existing_metadata_orig = pd.DataFrame({"rows": [1, 2], "batch": [1, 1]})
+    existing_results_orig = {
+        "results": pd.concat(
+            [existing_metadata_orig, pd.DataFrame({"value": [10, 20]})], axis=1
+        )
+    }
+    existing_metadata_orig.to_csv(output_paths.finished_sim_metadata, index=False)
+    existing_results_orig["results"].to_parquet(output_paths.results_dir / "results.parquet")
+
+    # create new metadata and results to write (larger than batch size of 2)
+    unwritten_metadata_orig = [
+        pd.DataFrame({"rows": [3], "batch": [2]}),
+        pd.DataFrame({"rows": [4], "batch": [2]}),
+        pd.DataFrame({"rows": [5], "batch": [3]}),
+    ]
+    unwritten_results_orig = []
+    batch_size = 2
+    for i in range(batch_size + 1):
+        unwritten_results_orig += [
+            {
+                "results": pd.concat(
+                    [unwritten_metadata_orig[i], pd.DataFrame({"value": [(i + 3) * 10]})],
+                    axis=1,
+                )
+            }
+        ]
+
+    (
+        existing_metadata,
+        unwritten_metadata,
+        existing_results,
+        unwritten_results,
+    ) = write_results_batch(
+        output_paths,
+        existing_metadata_orig,
+        existing_results_orig,
+        unwritten_metadata_orig,
+        unwritten_results_orig,
+        batch_size,
+    )
+
+    # check that updated existing metadata and results have been updated w/ a
+    # new batch of 2
+    assert existing_metadata.equals(
+        pd.concat(
+            [existing_metadata_orig] + unwritten_metadata_orig[:batch_size], axis=0
+        ).reset_index(drop=True)
+    )
+    assert existing_results["results"].equals(
+        pd.concat(
+            [existing_results_orig["results"]]
+            + [ur["results"] for ur in unwritten_results_orig[:batch_size]],
+            axis=0,
+        ).reset_index(drop=True)
+    )
+
+    # check that the same update metadata and results have been written out
+    assert existing_metadata.equals(pd.read_csv(output_paths.finished_sim_metadata))
+    assert existing_results["results"].equals(
+        pd.read_parquet(output_paths.results_dir / "results.parquet")
+    )
+
+    # check that the leftover unwritten metadata and results are returned
+    assert unwritten_metadata == unwritten_metadata_orig[batch_size:]
+    assert unwritten_results == unwritten_results_orig[batch_size:]

--- a/tests/psimulate/test_appending_perf_logs.py
+++ b/tests/psimulate/test_appending_perf_logs.py
@@ -77,7 +77,8 @@ def get_output_paths_from_output_directory(output_directory):
         model_specification=output_directory / "model_specification.yaml",
         keyspace=output_directory / "keyspace.yaml",
         branches=output_directory / "branches.yaml",
-        results=output_directory / "output.hdf",
+        finished_sim_metadata=output_directory / "finished_sim_metadata.csv",
+        results_dir=output_directory / "results",
     )
 
     return output_paths


### PR DESCRIPTION
## Update psimulate for new results processing
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> refactor, feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5096

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
This updates vct/psimulate to work with the new results processing approach.
Changes include:

- Updates to writing out since we now have a dictionary of datasets instead of a single dataset
- Without a single results dataset output.hdf, I instead write out a new 
  finished_sim_metadata.csv that has all of the non-results columns which
  are used by vct to determine job status
- Fixes to the long-standing job status update bug when restarting.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
pytests pass. I also ran test sims (child model but with only
mortality and base population):

- `psimulate run`
- `psimulate restart` (I ctrl+c'ed out of a sim to test this)
- `psimulate expand`
- --no-batch option
- batching (the batch size is currently hard-coded as 200). The test sim I was
  running was size 8 so I changed batch size to 2.

