### PR TITLE
Mic-5121/Hotfix pin numpy below 2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.6.1 - 06/17/24**
+
+ - Hotfix pin numpy below 2.0
+
 **1.6.0 - 03/12/24**
 
  - Limit max number of draws to 500.

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
 
     install_requires = [
         "pandas",
-        "numpy",
+        "numpy<2.0.0",
         "tables",
         "loguru",
         "pyyaml>=5.1",


### PR DESCRIPTION
## Mic-5121/Hotfix pin numpy below 2.0

### Pin numpy below 2.0 until we update to major version at later date.
- *Category*: Build
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5121

### Changes and notes
-pin numpy below 2.0

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

