### PR TITLE
Bugfix/sbachmei/mic 5139 export pythonhashseed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,8 @@ jobs:
         shell: bash -le {0}
     steps:
       - uses: actions/checkout@v3
+      - name: Set PYTHONHASHSEED
+        run: echo "PYTHONHASHSEED=42" >> $GITHUB_ENV
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -7,6 +7,7 @@ The main process loop for `psimulate` runs.
 
 """
 
+import os
 from collections import defaultdict
 from pathlib import Path
 from time import sleep, time
@@ -162,6 +163,18 @@ def main(
     no_batch: bool,
     extra_args: dict,
 ) -> None:
+
+    # PYTHONHASHSEED must be set outside the Python process. We don't want to
+    # be tricked if someone has modified it inside the Python process, since
+    # that will have no effect on the actual reproducibility of hashes.
+    if os.environ.get("PYTHONHASHSEED") != "42":
+        raise EnvironmentError(
+            "PYTHONHASHSEED must be set to 42 in the environment to ensure "
+            "reproducibility of hash-based operations.\n"
+            "Please run 'export PYTHONHASHSEED=42' from the command line "
+            "(or add to your .bashrc) before running the simulation."
+        )
+
     logger.info("Validating cluster environment.")
     cluster.validate_cluster_environment()
 


### PR DESCRIPTION
## Export PYTHONHASHSEED 42

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc --> bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5139

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> It turns out that we don't actually need to export the var
when launching off psimulate sruns - they're passed automatically.
So all I've done is raise early on if it's not set.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
tests pass. I also tried launching a psimulate w/o it set (all jobs failed)
and w/ it set (...all jobs also failed but NOT from the PYTHONHASHSEED
error and the jobs did indeed start running)
