### PR TITLE
Add Simulation Backups to PSimulate

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,3 @@
-**1.6.1 - 06/17/24**
-
- - Hotfix pin numpy below 2.0
-
 **1.6.0 - 03/12/24**
 
  - Limit max number of draws to 500.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**1.6.1 - 06/17/24**
+
+ - Hotfix pin numpy below 2.0
+
 **1.6.0 - 03/12/24**
 
  - Limit max number of draws to 500.

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ if __name__ == "__main__":
         "requests",
         "layered_config_tree>=1.0.1",
         "pyarrow",
+        
     ]
 
     setup_requires = ["setuptools_scm"]

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
 
     install_requires = [
         "pandas",
-        "numpy<2.0.0",
+        "numpy",
         "tables",
         "loguru",
         "pyyaml>=5.1",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ if __name__ == "__main__":
 
     install_requires = [
         "pandas",
-        "numpy",
+        "numpy<2.0.0",
         "tables",
         "loguru",
         "pyyaml>=5.1",

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,6 @@ if __name__ == "__main__":
         "requests",
         "layered_config_tree>=1.0.1",
         "pyarrow",
-        
     ]
 
     setup_requires = ["setuptools_scm"]

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ if __name__ == "__main__":
         "loguru",
         "pyyaml>=5.1",
         "drmaa",
+        "dill",
         "redis",
         "rq",
         "vivarium>=1.2.1",

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ if __name__ == "__main__":
         "psutil",
         "requests",
         "layered_config_tree>=1.0.1",
+        "pyarrow",
     ]
 
     setup_requires = ["setuptools_scm"]

--- a/src/vivarium_cluster_tools/cli_tools.py
+++ b/src/vivarium_cluster_tools/cli_tools.py
@@ -44,7 +44,7 @@ def pass_shared_options(shared_options: List[Decorator]) -> Decorator:
 
 class MinutesOrNone(click.ParamType):
     """Click param type to allow user to set time in minutes or None."""
-
+    name = "minutesornone"
     def convert(self, value, param, ctx):
         try:
             if value.lower() == "none":
@@ -54,3 +54,5 @@ class MinutesOrNone(click.ParamType):
         except ValueError:
             # Raise error if conversion to int fails and value is not 'none'
             self.fail(f"{value!r} is not a valid integer or 'none'", param, ctx)
+
+MINUTES_OR_NONE = MinutesOrNone()

--- a/src/vivarium_cluster_tools/cli_tools.py
+++ b/src/vivarium_cluster_tools/cli_tools.py
@@ -40,3 +40,17 @@ def pass_shared_options(shared_options: List[Decorator]) -> Decorator:
         return func
 
     return _pass_shared_options
+
+
+class MinutesOrNone(click.ParamType):
+    name = "minutesornone"
+
+    def convert(self, value, param, ctx):
+        try:
+            if value.lower() == "none":
+                return None
+            # Convert minutes to seconds
+            return float(value * 60)
+        except ValueError:
+            # Raise error if conversion to int fails and value is not 'none'
+            self.fail(f"{value!r} is not a valid integer or 'none'", param, ctx)

--- a/src/vivarium_cluster_tools/cli_tools.py
+++ b/src/vivarium_cluster_tools/cli_tools.py
@@ -43,7 +43,7 @@ def pass_shared_options(shared_options: List[Decorator]) -> Decorator:
 
 
 class MinutesOrNone(click.ParamType):
-    name = "minutesornone"
+    """Click param type to allow user to set time in minutes or None."""
 
     def convert(self, value, param, ctx):
         try:

--- a/src/vivarium_cluster_tools/cli_tools.py
+++ b/src/vivarium_cluster_tools/cli_tools.py
@@ -55,7 +55,7 @@ class MinutesOrNone(click.ParamType):
             return float(value * 60)
         except ValueError:
             # Raise error if conversion to int fails and value is not 'none'
-            self.fail(f"{value!r} is not a valid integer or 'none'", param, ctx)
+            click.ParamType.fail(f"{value!r} is not a valid integer or 'none'", param, ctx)
 
 
 MINUTES_OR_NONE = MinutesOrNone()

--- a/src/vivarium_cluster_tools/cli_tools.py
+++ b/src/vivarium_cluster_tools/cli_tools.py
@@ -48,7 +48,7 @@ class MinutesOrNone(click.ParamType):
     name = "minutesornone"
 
     def convert(self, value: str, param: str, ctx: click.Context) -> Optional[float]:
-        """Converts the value to float seconds from minutes. 
+        """Converts the value to float seconds from minutes.
         If conversion fails, calls the `fail` method from `click.ParamType`.
         """
         try:
@@ -58,5 +58,6 @@ class MinutesOrNone(click.ParamType):
             return float(value * 60)
         except ValueError:
             click.ParamType.fail(f"{value!r} is not a valid float or 'none'", param, ctx)
+
 
 MINUTES_OR_NONE = MinutesOrNone()

--- a/src/vivarium_cluster_tools/cli_tools.py
+++ b/src/vivarium_cluster_tools/cli_tools.py
@@ -44,7 +44,9 @@ def pass_shared_options(shared_options: List[Decorator]) -> Decorator:
 
 class MinutesOrNone(click.ParamType):
     """Click param type to allow user to set time in minutes or None."""
+
     name = "minutesornone"
+
     def convert(self, value, param, ctx):
         try:
             if value.lower() == "none":
@@ -54,5 +56,6 @@ class MinutesOrNone(click.ParamType):
         except ValueError:
             # Raise error if conversion to int fails and value is not 'none'
             self.fail(f"{value!r} is not a valid integer or 'none'", param, ctx)
+
 
 MINUTES_OR_NONE = MinutesOrNone()

--- a/src/vivarium_cluster_tools/cli_tools.py
+++ b/src/vivarium_cluster_tools/cli_tools.py
@@ -5,7 +5,7 @@ Shared CLI tools
 
 """
 from pathlib import Path
-from typing import Callable, List
+from typing import Callable, List, Optional
 
 import click
 
@@ -47,15 +47,16 @@ class MinutesOrNone(click.ParamType):
 
     name = "minutesornone"
 
-    def convert(self, value, param, ctx):
+    def convert(self, value: str, param: str, ctx: click.Context) -> Optional[float]:
+        """Converts the value to float seconds from minutes. 
+        If conversion fails, calls the `fail` method from `click.ParamType`.
+        """
         try:
             if value.lower() == "none":
                 return None
             # Convert minutes to seconds
             return float(value * 60)
         except ValueError:
-            # Raise error if conversion to int fails and value is not 'none'
-            click.ParamType.fail(f"{value!r} is not a valid integer or 'none'", param, ctx)
-
+            click.ParamType.fail(f"{value!r} is not a valid float or 'none'", param, ctx)
 
 MINUTES_OR_NONE = MinutesOrNone()

--- a/src/vivarium_cluster_tools/cli_tools.py
+++ b/src/vivarium_cluster_tools/cli_tools.py
@@ -55,7 +55,7 @@ class MinutesOrNone(click.ParamType):
             if value.lower() == "none":
                 return None
             # Convert minutes to seconds
-            return float(value * 60)
+            return float(value) * 60.0
         except ValueError:
             click.ParamType.fail(f"{value!r} is not a valid float or 'none'", param, ctx)
 

--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -51,6 +51,8 @@ shared_options = [
     redis_dbs.with_max_workers,
     redis_dbs.with_redis,
     results.with_no_batch,
+    results.with_sim_backup,
+    results.sim_backup_freq,
     cli_tools.with_verbose_and_pdb,
 ]
 
@@ -132,6 +134,8 @@ def run(
         max_workers=options["max_workers"],
         redis_processes=options["redis"],
         no_batch=options["no_batch"],
+        make_backups=options["make_backups"],
+        backup_freq=options["backup_freq"],
         extra_args={},
     )
 
@@ -170,6 +174,8 @@ def restart(results_root, **options):
         max_workers=options["max_workers"],
         redis_processes=options["redis"],
         no_batch=options["no_batch"],
+        make_backups=options["make_backups"],
+        backup_freq=options["backup_freq"],
         extra_args={},
     )
 
@@ -224,6 +230,8 @@ def expand(results_root, **options):
         max_workers=options["max_workers"],
         redis_processes=options["redis"],
         no_batch=options["no_batch"],
+        make_backups=options["make_backups"],
+        backup_freq=options["backup_freq"],
         extra_args={
             "num_draws": options["add_draws"],
             "num_seeds": options["add_seeds"],
@@ -295,6 +303,8 @@ def test(test_type, num_workers, result_directory, **options):
         max_workers=options["max_workers"],
         redis_processes=options["redis"],
         no_batch=options["no_batch"],
+        make_backups=options["make_backups"],
+        backup_freq=options["backup_freq"],
         extra_args={
             "test_type": test_type,
             "num_workers": num_workers,

--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -52,7 +52,7 @@ shared_options = [
     redis_dbs.with_redis,
     results.with_no_batch,
     results.with_sim_backup,
-    results.sim_backup_freq,
+    results.backup_freq,
     cli_tools.with_verbose_and_pdb,
 ]
 

--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -51,7 +51,7 @@ shared_options = [
     redis_dbs.with_max_workers,
     redis_dbs.with_redis,
     results.with_no_batch,
-    results.with_sim_backup,
+    results.with_make_backups,
     results.backup_freq,
     cli_tools.with_verbose_and_pdb,
 ]

--- a/src/vivarium_cluster_tools/psimulate/cli.py
+++ b/src/vivarium_cluster_tools/psimulate/cli.py
@@ -51,7 +51,6 @@ shared_options = [
     redis_dbs.with_max_workers,
     redis_dbs.with_redis,
     results.with_no_batch,
-    results.with_make_backups,
     results.backup_freq,
     cli_tools.with_verbose_and_pdb,
 ]
@@ -134,7 +133,6 @@ def run(
         max_workers=options["max_workers"],
         redis_processes=options["redis"],
         no_batch=options["no_batch"],
-        make_backups=options["make_backups"],
         backup_freq=options["backup_freq"],
         extra_args={},
     )
@@ -174,7 +172,6 @@ def restart(results_root, **options):
         max_workers=options["max_workers"],
         redis_processes=options["redis"],
         no_batch=options["no_batch"],
-        make_backups=options["make_backups"],
         backup_freq=options["backup_freq"],
         extra_args={},
     )
@@ -230,7 +227,6 @@ def expand(results_root, **options):
         max_workers=options["max_workers"],
         redis_processes=options["redis"],
         no_batch=options["no_batch"],
-        make_backups=options["make_backups"],
         backup_freq=options["backup_freq"],
         extra_args={
             "num_draws": options["add_draws"],
@@ -303,7 +299,6 @@ def test(test_type, num_workers, result_directory, **options):
         max_workers=options["max_workers"],
         redis_processes=options["redis"],
         no_batch=options["no_batch"],
-        make_backups=options["make_backups"],
         backup_freq=options["backup_freq"],
         extra_args={
             "test_type": test_type,

--- a/src/vivarium_cluster_tools/psimulate/jobs.py
+++ b/src/vivarium_cluster_tools/psimulate/jobs.py
@@ -23,6 +23,7 @@ class JobParameters(NamedTuple):
     input_draw: int
     random_seed: int
     results_path: str
+    backup_configuration: dict
     extras: dict
 
     @property
@@ -31,6 +32,7 @@ class JobParameters(NamedTuple):
         return {
             "model_specification": self.model_specification,
             "results_path": self.results_path,
+            "backup_configuration": self.backup_configuration,
         }
 
     @property
@@ -62,6 +64,8 @@ def build_job_list(
     finished_sim_metadata: pd.DataFrame,
     make_backups: bool,
     backup_freq: int,
+    backup_dir: Path,
+    backup_metadata_path: Path,
     extras: dict,
 ) -> Tuple[List[dict], int]:
     jobs = []
@@ -75,7 +79,13 @@ def build_job_list(
                 input_draw=int(input_draw),
                 random_seed=int(random_seed),
                 results_path=str(output_root),
-                extras={"backup_freq": backup_freq * 60} if make_backups else {},
+                backup_configuration={
+                    "make_backups": make_backups,
+                    "backup_dir": backup_dir,
+                    "backup_freq": backup_freq * 60,
+                    "backup_metadata_path": backup_metadata_path,
+                },
+                extras={},
             )
 
             if already_complete(parameters, finished_sim_metadata):

--- a/src/vivarium_cluster_tools/psimulate/jobs.py
+++ b/src/vivarium_cluster_tools/psimulate/jobs.py
@@ -6,7 +6,7 @@ psimulate Jobs
 """
 
 from pathlib import Path
-from typing import List, NamedTuple, Tuple
+from typing import List, NamedTuple, Optional, Tuple
 
 import numpy as np
 import pandas as pd
@@ -62,8 +62,7 @@ def build_job_list(
     output_root: Path,
     keyspace: branches.Keyspace,
     finished_sim_metadata: pd.DataFrame,
-    make_backups: bool,
-    backup_freq: int,
+    backup_freq: Optional[int],
     backup_dir: Path,
     backup_metadata_path: Path,
     extras: dict,
@@ -80,9 +79,10 @@ def build_job_list(
                 random_seed=int(random_seed),
                 results_path=str(output_root),
                 backup_configuration={
-                    "make_backups": make_backups,
                     "backup_dir": backup_dir,
-                    "backup_freq": backup_freq * 60,
+                    "backup_freq": backup_freq * 60
+                    if backup_freq is not None
+                    else backup_freq,
                     "backup_metadata_path": backup_metadata_path,
                 },
                 extras={},

--- a/src/vivarium_cluster_tools/psimulate/jobs.py
+++ b/src/vivarium_cluster_tools/psimulate/jobs.py
@@ -60,6 +60,8 @@ def build_job_list(
     output_root: Path,
     keyspace: branches.Keyspace,
     finished_sim_metadata: pd.DataFrame,
+    make_backups: bool,
+    backup_freq: int,
     extras: dict,
 ) -> Tuple[List[dict], int]:
     jobs = []
@@ -73,7 +75,7 @@ def build_job_list(
                 input_draw=int(input_draw),
                 random_seed=int(random_seed),
                 results_path=str(output_root),
-                extras={},
+                extras={"backup_freq": backup_freq * 60} if make_backups else {},
             )
 
             if already_complete(parameters, finished_sim_metadata):

--- a/src/vivarium_cluster_tools/psimulate/jobs.py
+++ b/src/vivarium_cluster_tools/psimulate/jobs.py
@@ -80,7 +80,9 @@ def build_job_list(
                 results_path=str(output_root),
                 backup_configuration={
                     "backup_dir": backup_dir,
-                    "backup_freq": backup_freq,
+                    "backup_freq": backup_freq * 60
+                    if backup_freq is not None
+                    else backup_freq,
                     "backup_metadata_path": backup_metadata_path,
                 },
                 extras={},

--- a/src/vivarium_cluster_tools/psimulate/jobs.py
+++ b/src/vivarium_cluster_tools/psimulate/jobs.py
@@ -80,9 +80,7 @@ def build_job_list(
                 results_path=str(output_root),
                 backup_configuration={
                     "backup_dir": backup_dir,
-                    "backup_freq": backup_freq * 60
-                    if backup_freq is not None
-                    else backup_freq,
+                    "backup_freq": backup_freq,
                     "backup_metadata_path": backup_metadata_path,
                 },
                 extras={},

--- a/src/vivarium_cluster_tools/psimulate/paths.py
+++ b/src/vivarium_cluster_tools/psimulate/paths.py
@@ -72,6 +72,8 @@ class OutputPaths(NamedTuple):
     # outputs
     finished_sim_metadata: Path
     results_dir: Path
+    backup_dir: Path
+    backup_metadata_path: Path
 
     # will not be reliable if we parallelized across artifacts
     @property
@@ -146,11 +148,13 @@ class OutputPaths(NamedTuple):
             branches=output_directory / "branches.yaml",
             finished_sim_metadata=output_directory / "finished_sim_metadata.csv",
             results_dir=output_directory / "results",
+            backup_dir=output_directory / "sim_backups",
+            backup_metadata_path=output_directory / "sim_backups" / "backup_metadata.csv",
         )
         return output_paths
 
     def touch(self) -> None:
-        for dir in [self.root, self.results_dir]:
+        for dir in [self.root, self.results_dir, self.backup_dir]:
             vct_utils.mkdir(dir, exists_ok=True, parents=True)
         for dir in [self.logging_root, self.cluster_logging_root, self.worker_logging_root]:
             vct_utils.mkdir(dir, parents=True)

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
@@ -10,6 +10,7 @@ Unified interface to multiple Redis Databases.
 import random
 import time
 from collections import defaultdict
+from itertools import chain
 from typing import Any, Dict, Iterator, List, Tuple, Union
 
 import redis
@@ -301,8 +302,6 @@ class RegistryManager:
         return status
 
     def get_params_by_job(self):
-        from itertools import chain
-
         jobs = list(chain.from_iterable([q._queue.jobs for q in self._queues]))
         return {job.id: job.kwargs["job_parameters"] for job in jobs}
 

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
@@ -301,7 +301,7 @@ class RegistryManager:
         self._logger.info(template.format(**status))
         return status
 
-    def get_params_by_job(self):
+    def get_params_by_job(self) -> dict[str, dict]:
         jobs = list(chain.from_iterable([q._queue.jobs for q in self._queues]))
         return {job.id: job.kwargs["job_parameters"] for job in jobs}
 

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
@@ -300,5 +300,11 @@ class RegistryManager:
         self._logger.info(template.format(**status))
         return status
 
+    def get_params_by_job(self):
+        from itertools import chain
+
+        jobs = list(chain.from_iterable([q._queue.jobs for q in self._queues]))
+        return {job.id: job.kwargs["job_parameters"] for job in jobs}
+
     def __len__(self) -> int:
         return len(self._queues)

--- a/src/vivarium_cluster_tools/psimulate/results/__init__.py
+++ b/src/vivarium_cluster_tools/psimulate/results/__init__.py
@@ -6,7 +6,6 @@ Results Management
 """
 from vivarium_cluster_tools.psimulate.results.cli_options import (
     backup_freq,
-    with_make_backups,
     with_no_batch,
     with_no_cleanup,
 )

--- a/src/vivarium_cluster_tools/psimulate/results/__init__.py
+++ b/src/vivarium_cluster_tools/psimulate/results/__init__.py
@@ -5,7 +5,9 @@ Results Management
 
 """
 from vivarium_cluster_tools.psimulate.results.cli_options import (
+    backup_freq,
     with_no_batch,
     with_no_cleanup,
+    with_sim_backup,
 )
 from vivarium_cluster_tools.psimulate.results.processing import write_results_batch

--- a/src/vivarium_cluster_tools/psimulate/results/__init__.py
+++ b/src/vivarium_cluster_tools/psimulate/results/__init__.py
@@ -6,8 +6,8 @@ Results Management
 """
 from vivarium_cluster_tools.psimulate.results.cli_options import (
     backup_freq,
+    with_make_backups,
     with_no_batch,
     with_no_cleanup,
-    with_make_backups,
 )
 from vivarium_cluster_tools.psimulate.results.processing import write_results_batch

--- a/src/vivarium_cluster_tools/psimulate/results/__init__.py
+++ b/src/vivarium_cluster_tools/psimulate/results/__init__.py
@@ -8,6 +8,6 @@ from vivarium_cluster_tools.psimulate.results.cli_options import (
     backup_freq,
     with_no_batch,
     with_no_cleanup,
-    with_sim_backup,
+    with_make_backups,
 )
 from vivarium_cluster_tools.psimulate.results.processing import write_results_batch

--- a/src/vivarium_cluster_tools/psimulate/results/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/results/cli_options.py
@@ -18,13 +18,9 @@ with_no_cleanup = click.option(
     help="Hidden developer option, if flagged, don't automatically "
     "cleanup results directory on failure.",
 )
-with_make_backups = click.option(
-    "--make-backups", is_flag=True, help="Periodically save simulation state to disk."
-)
 backup_freq = click.option(
     "--backup-freq",
-    type=int,
-    default=5,
+    default=None,
     show_default=True,
-    help="Interval in hours between saving backups.",
+    help="Interval in seconds between saving backups.",
 )

--- a/src/vivarium_cluster_tools/psimulate/results/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/results/cli_options.py
@@ -23,7 +23,7 @@ with_no_cleanup = click.option(
 backup_freq = click.option(
     "--backup-freq",
     type=MINUTES_OR_NONE,
-    default=30,
+    default="30",
     show_default=True,
     help="Interval in minutes between saving backups. Set to 'None' or 'none' to disable backups.",
 )

--- a/src/vivarium_cluster_tools/psimulate/results/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/results/cli_options.py
@@ -20,7 +20,7 @@ with_no_cleanup = click.option(
 )
 backup_freq = click.option(
     "--backup-freq",
-    default=None,
+    default=30,
     show_default=True,
-    help="Interval in seconds between saving backups.",
+    help="Interval in minutes between saving backups.",
 )

--- a/src/vivarium_cluster_tools/psimulate/results/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/results/cli_options.py
@@ -18,7 +18,7 @@ with_no_cleanup = click.option(
     help="Hidden developer option, if flagged, don't automatically "
     "cleanup results directory on failure.",
 )
-with_sim_backup = click.option(
+with_make_backups = click.option(
     "--make-backups", is_flag=True, help="Periodically save simulation state to disk."
 )
 backup_freq = click.option(

--- a/src/vivarium_cluster_tools/psimulate/results/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/results/cli_options.py
@@ -8,6 +8,8 @@ Command line options for configuring results handling in psimulate runs.
 """
 import click
 
+from vivarium_cluster_tools.cli_tools import MinutesOrNone
+
 with_no_batch = click.option(
     "--no-batch", is_flag=True, help="Don't batch results, write them as they come in."
 )
@@ -20,7 +22,8 @@ with_no_cleanup = click.option(
 )
 backup_freq = click.option(
     "--backup-freq",
+    type=MinutesOrNone(),
     default=30,
     show_default=True,
-    help="Interval in minutes between saving backups.",
+    help="Interval in minutes between saving backups. Set to 'None' or 'none' to disable backups.",
 )

--- a/src/vivarium_cluster_tools/psimulate/results/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/results/cli_options.py
@@ -18,3 +18,13 @@ with_no_cleanup = click.option(
     help="Hidden developer option, if flagged, don't automatically "
     "cleanup results directory on failure.",
 )
+with_sim_backup = click.option("--make_backups",
+                               is_flag=True,
+                               help="Periodically save simulation state to disk.")
+backup_freq = click.option(
+    "--backup_freq",
+    type=int,
+    default=5,
+    show_default=True,
+    help="Interval in hours between saving backups.",
+)

--- a/src/vivarium_cluster_tools/psimulate/results/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/results/cli_options.py
@@ -18,11 +18,11 @@ with_no_cleanup = click.option(
     help="Hidden developer option, if flagged, don't automatically "
     "cleanup results directory on failure.",
 )
-with_sim_backup = click.option("--make_backups",
-                               is_flag=True,
-                               help="Periodically save simulation state to disk.")
+with_sim_backup = click.option(
+    "--make-backups", is_flag=True, help="Periodically save simulation state to disk."
+)
 backup_freq = click.option(
-    "--backup_freq",
+    "--backup-freq",
     type=int,
     default=5,
     show_default=True,

--- a/src/vivarium_cluster_tools/psimulate/results/cli_options.py
+++ b/src/vivarium_cluster_tools/psimulate/results/cli_options.py
@@ -8,7 +8,7 @@ Command line options for configuring results handling in psimulate runs.
 """
 import click
 
-from vivarium_cluster_tools.cli_tools import MinutesOrNone
+from vivarium_cluster_tools.cli_tools import MINUTES_OR_NONE
 
 with_no_batch = click.option(
     "--no-batch", is_flag=True, help="Don't batch results, write them as they come in."
@@ -22,7 +22,7 @@ with_no_cleanup = click.option(
 )
 backup_freq = click.option(
     "--backup-freq",
-    type=MinutesOrNone(),
+    type=MINUTES_OR_NONE,
     default=30,
     show_default=True,
     help="Interval in minutes between saving backups. Set to 'None' or 'none' to disable backups.",

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -348,6 +348,9 @@ def main(
             f"*** NOTE: There {'was' if status['failed'] == 1 else 'were'} "
             f"{status['failed']} failed job{'' if status['failed'] == 1 else 's'}. ***"
         )
+    else:
+        logger.info(f"Removing sim backup directory {output_paths.backup_dir}")
+        os.remove(output_paths.backup_dir)
 
     logger.info(
         f"{status['successful'] - num_jobs_completed} of {status['total']} jobs "

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -160,6 +160,8 @@ def main(
     max_workers: Optional[int],
     redis_processes: int,
     no_batch: bool,
+    backup_sim: bool,
+    sim_backup_freq: int,
     extra_args: dict,
 ) -> None:
     logger.info("Validating cluster environment.")
@@ -228,6 +230,8 @@ def main(
         output_root=output_paths.root,
         keyspace=keyspace,
         finished_sim_metadata=finished_sim_metadata,
+        make_backups=options["make_backups"],
+        backup_freq=options["backup_freq"],
         extras=extra_args,
     )
     # Let the user know if something is fishy at this point.

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -153,8 +153,9 @@ def try_run_vipin(output_paths: OutputPaths) -> None:
         logger.warning(f"Appending performance data to central logs failed with: {e}")
 
 
-def write_backup_metadata(output_paths: OutputPaths, registry_manager) -> None:
-    parameters_by_job = registry_manager.get_params_by_job()
+def write_backup_metadata(
+    backup_metadata_path: Path, parameters_by_job: dict[str, dict]
+) -> None:
     lookup_table = []
     for job_id, params in parameters_by_job.items():
         job_dict = {
@@ -168,7 +169,7 @@ def write_backup_metadata(output_paths: OutputPaths, registry_manager) -> None:
         lookup_table.append(job_dict)
 
     df = pd.DataFrame(lookup_table)
-    df.to_csv(output_paths.backup_metadata_path)
+    df.to_csv(backup_metadata_path, index=False)
 
 
 def main(
@@ -284,7 +285,10 @@ def main(
     )
 
     if make_backups:
-        write_backup_metadata(output_paths, registry_manager)
+        write_backup_metadata(
+            backup_metadata_path=output_paths.backup_metadata_path,
+            parameters_by_job=registry_manager.get_params_by_job(),
+        )
     # Generate a worker template that chooses a redis DB at random to connect to.
     # This should (approximately) evenly distribute the workers over the work.
     redis_urls = [f"redis://{hostname}:{port}" for hostname, port in redis_ports]

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -14,6 +14,7 @@ from typing import Dict, Optional, Union
 
 import pandas as pd
 from loguru import logger
+from vivarium.framework.utilities import collapse_nested_dict
 
 from vivarium_cluster_tools import logs
 from vivarium_cluster_tools.psimulate import (
@@ -42,7 +43,6 @@ def process_job_results(
     output_paths: OutputPaths,
     no_batch: bool,
 ) -> Dict[str, Union[int, float]]:
-
     unwritten_metadata = []
     unwritten_results = []
     batch_size = 0 if no_batch else 200
@@ -153,6 +153,24 @@ def try_run_vipin(output_paths: OutputPaths) -> None:
         logger.warning(f"Appending performance data to central logs failed with: {e}")
 
 
+def write_backup_metadata(output_paths: OutputPaths, registry_manager) -> None:
+    parameters_by_job = registry_manager.get_params_by_job()
+    lookup_table = []
+    for job_id, params in parameters_by_job.items():
+        job_dict = {
+            "input_draw": params["input_draw"],
+            "random_seed": params["random_seed"],
+            "job_id": job_id,
+        }
+        branch_config = collapse_nested_dict(params["branch_configuration"])
+        for k, v in branch_config:
+            job_dict[k] = v
+        lookup_table.append(job_dict)
+
+    df = pd.DataFrame(lookup_table)
+    df.to_csv(output_paths.backup_metadata_path)
+
+
 def main(
     command: str,
     input_paths: paths.InputPaths,
@@ -160,8 +178,8 @@ def main(
     max_workers: Optional[int],
     redis_processes: int,
     no_batch: bool,
-    backup_sim: bool,
-    sim_backup_freq: int,
+    make_backups: bool,
+    backup_freq: int,
     extra_args: dict,
 ) -> None:
     logger.info("Validating cluster environment.")
@@ -230,8 +248,10 @@ def main(
         output_root=output_paths.root,
         keyspace=keyspace,
         finished_sim_metadata=finished_sim_metadata,
-        make_backups=options["make_backups"],
-        backup_freq=options["backup_freq"],
+        make_backups=make_backups,
+        backup_freq=backup_freq,
+        backup_dir=output_paths.backup_dir,
+        backup_metadata_path=output_paths.backup_metadata_path,
         extras=extra_args,
     )
     # Let the user know if something is fishy at this point.
@@ -262,6 +282,9 @@ def main(
     registry_manager.enqueue(
         jobs=job_parameters, workhorse_import_path=worker.WORK_HORSE_PATHS[command]
     )
+
+    if make_backups:
+        write_backup_metadata(output_paths, registry_manager)
     # Generate a worker template that chooses a redis DB at random to connect to.
     # This should (approximately) evenly distribute the workers over the work.
     redis_urls = [f"redis://{hostname}:{port}" for hostname, port in redis_ports]

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -179,7 +179,6 @@ def main(
     max_workers: Optional[int],
     redis_processes: int,
     no_batch: bool,
-    make_backups: bool,
     backup_freq: int,
     extra_args: dict,
 ) -> None:
@@ -249,7 +248,6 @@ def main(
         output_root=output_paths.root,
         keyspace=keyspace,
         finished_sim_metadata=finished_sim_metadata,
-        make_backups=make_backups,
         backup_freq=backup_freq,
         backup_dir=output_paths.backup_dir,
         backup_metadata_path=output_paths.backup_metadata_path,
@@ -284,7 +282,7 @@ def main(
         jobs=job_parameters, workhorse_import_path=worker.WORK_HORSE_PATHS[command]
     )
 
-    if make_backups:
+    if backup_freq is not None:
         write_backup_metadata(
             backup_metadata_path=output_paths.backup_metadata_path,
             parameters_by_job=registry_manager.get_params_by_job(),

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -169,7 +169,7 @@ def write_backup_metadata(
         lookup_table.append(job_dict)
 
     df = pd.DataFrame(lookup_table)
-    df.to_csv(backup_metadata_path, index=False)
+    df.to_csv(backup_metadata_path, index=False, mode='a', header=not os.path.exists(output_path))
 
 
 def main(

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -8,6 +8,7 @@ The main process loop for `psimulate` runs.
 """
 
 import os
+import shutil
 from collections import defaultdict
 from pathlib import Path
 from time import sleep, time
@@ -350,7 +351,7 @@ def main(
         )
     else:
         logger.info(f"Removing sim backup directory {output_paths.backup_dir}")
-        os.remove(output_paths.backup_dir)
+        shutil.rmtree(output_paths.backup_dir)
 
     logger.info(
         f"{status['successful'] - num_jobs_completed} of {status['total']} jobs "

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -7,6 +7,7 @@ The main process loop for `psimulate` runs.
 
 """
 
+import os
 from collections import defaultdict
 from pathlib import Path
 from time import sleep, time
@@ -169,7 +170,12 @@ def write_backup_metadata(
         lookup_table.append(job_dict)
 
     df = pd.DataFrame(lookup_table)
-    df.to_csv(backup_metadata_path, index=False, mode='a', header=not os.path.exists(output_path))
+    df.to_csv(
+        backup_metadata_path,
+        index=False,
+        mode="a",
+        header=not os.path.exists(backup_metadata_path),
+    )
 
 
 def main(

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -94,9 +94,7 @@ def work_horse(job_parameters: dict) -> Tuple[pd.DataFrame, Dict[str, pd.DataFra
         ).with_suffix(".pkl")
         sim.run(
             backup_freq=job_parameters.backup_configuration["backup_freq"],
-            backup_path=(
-                job_parameters.backup_configuration["backup_dir"] / str(get_current_job().id)
-            ).with_suffix(".pkl"),
+            backup_path=backup_path,
         )
         event["results_start"] = time()
         exec_time["main_loop_minutes"] = (
@@ -117,7 +115,7 @@ def work_horse(job_parameters: dict) -> Tuple[pd.DataFrame, Dict[str, pd.DataFra
         do_sim_epilogue(start_snapshot, end_snapshot, event, exec_time, job_parameters)
         results = sim.get_results()  # Dict[measure, results dataframe]
         finished_results_metadata = format_and_record_details(job_parameters, results)
-        remove_backups(job_parameters.backup_configuration["backup_dir"])
+        remove_backups(backup_path)
 
         return finished_results_metadata, results
 
@@ -265,8 +263,7 @@ def get_backup(job_parameters: JobParameters) -> Optional[SimulationContext]:
         return None
 
 
-def remove_backups(backup_dir: Path) -> None:
-    backup_path = (backup_dir / str(get_current_job().id)).with_suffix(".pkl")
+def remove_backups(backup_path: Path) -> None:
     try:
         os.remove(backup_path)
     except FileNotFoundError:

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -260,7 +260,9 @@ def get_backup(job_parameters: JobParameters) -> Optional[SimulationContext]:
                 os.rename(last_pickle, (backup_dir / str(current_job_id)).with_suffix(".pkl"))
             return sim
     except (OSError, FileNotFoundError):
-        logger.info("Missing backup or backup directory. Restarting simulation from beginning.")
+        logger.info(
+            "Missing backup or backup directory. Restarting simulation from beginning."
+        )
         return None
     except Exception as e:
         logger.warning(f"Load from backup failed with Exception: {e}")

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -11,7 +11,7 @@ import json
 import math
 import os
 from pathlib import Path
-from time import time, sleep
+from time import sleep, time
 from traceback import format_exc
 from typing import Dict, Optional, Tuple, Union
 
@@ -89,11 +89,14 @@ def work_horse(job_parameters: dict) -> Tuple[pd.DataFrame, Dict[str, pd.DataFra
         step_size = pd.Timedelta(days=sim.configuration.time.step_size)
         num_steps = int(math.ceil((end_time - start_time) / step_size))
         logger.info(f"Starting main simulation loop with {num_steps} time steps")
-        backup_path = (job_parameters.backup_configuration["backup_dir"] / str(get_current_job().id)).with_suffix(".pkl")
-        logger.info(f"backup path: {backup_path}")
+        backup_path = (
+            job_parameters.backup_configuration["backup_dir"] / str(get_current_job().id)
+        ).with_suffix(".pkl")
         sim.run(
             backup_freq=job_parameters.backup_configuration["backup_freq"],
-            backup_path=(job_parameters.backup_configuration["backup_dir"] / str(get_current_job().id)).with_suffix(".pkl"),
+            backup_path=(
+                job_parameters.backup_configuration["backup_dir"] / str(get_current_job().id)
+            ).with_suffix(".pkl"),
         )
         event["results_start"] = time()
         exec_time["main_loop_minutes"] = (

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -224,23 +224,6 @@ def format_and_record_details(
     return finished_results_metadata
 
 
-def parameter_update_format(job_parameters: JobParameters) -> dict:
-    return {
-        "run_configuration": {
-            "run_id": str(get_current_job().id) + "_" + str(time()),
-            "results_directory": job_parameters.results_path,
-            "run_key": job_parameters.job_specific,
-        },
-        "randomness": {
-            "random_seed": job_parameters.random_seed,
-            "additional_seed": job_parameters.input_draw,
-        },
-        "input_data": {
-            "input_draw_number": job_parameters.input_draw,
-        },
-    }
-
-
 def run(sim: SimulationContext, job_parameters: JobParameters):
     backup_freq = job_parameters.backup_configuration["backup_freq"]
     if backup_freq:

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -275,9 +275,9 @@ def get_backup(job_parameters: JobParameters) -> Optional[SimulationContext]:
     # Use the query method to find rows that match the lookup parameters
     run_ids = pickle_metadata.query(query_conditions)["job_id"].to_list()
     if run_ids:
-        filename = Path(run_ids[0] + ".pkl")
+        filename = Path(backup_dir / run_ids[0]).with_suffix(".pkl")
         if filename.exists():
-            with open(backup_dir / filename, "rb") as f:
+            with open(filename, "rb") as f:
                 sim = dill.load(f)
             return sim
     return None

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -109,7 +109,7 @@ def work_horse(job_parameters: dict) -> Tuple[pd.DataFrame, Dict[str, pd.DataFra
         do_sim_epilogue(start_snapshot, end_snapshot, event, exec_time, job_parameters)
         results = sim.get_results()  # Dict[measure, results dataframe]
         finished_results_metadata = format_and_record_details(job_parameters, results)
-        remove_backups(job_parameters)
+        remove_backups(job_parameters.backup_configuration["backup_dir"])
 
         return finished_results_metadata, results
 
@@ -261,8 +261,7 @@ def get_backup(job_parameters: JobParameters) -> Optional[SimulationContext]:
     return None
 
 
-def remove_backups(job_parameters) -> None:
-    backup_dir = job_parameters.backup_configuration["backup_dir"]
+def remove_backups(backup_dir: Path) -> None:
     backup_path = (backup_dir / str(get_current_job().id)).with_suffix(".pkl")
     try:
         os.remove(backup_path)

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -259,7 +259,12 @@ def get_backup(job_parameters: JobParameters) -> Optional[SimulationContext]:
                 sleep(5)
                 os.rename(last_pickle, (backup_dir / str(current_job_id)).with_suffix(".pkl"))
             return sim
-    except (OSError, FileNotFoundError, EOFError):
+    except OSError, FileNotFoundError:
+        logger.info("Missing backup or backup directory. Restarting simulation from beginning.")
+        return None
+    except Exception as e:
+        logger.warning(f"Load from backup failed with Exception: {e}")
+        logger.warning("Restarting simulation from beginning.")
         return None
 
 

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -92,7 +92,7 @@ def work_horse(job_parameters: dict) -> Tuple[pd.DataFrame, Dict[str, pd.DataFra
         sim.run(
             sim,
             backup_freq=job_parameters.backup_configuration["backup_freq"],
-            backup_path=job_parameters.backup_configuration["backup_dir"],
+            backup_path=job_parameters.backup_configuration["backup_dir"] / str(get_current_job().id)).with_suffix(".pkl"),
         )
         event["results_start"] = time()
         exec_time["main_loop_minutes"] = (
@@ -236,11 +236,20 @@ def get_backup(job_parameters: JobParameters) -> Optional[SimulationContext]:
 
         # Use the query method to find rows that match the lookup parameters
         run_ids = pickle_metadata.query(query_conditions)["job_id"].to_list()
-        if run_ids:
-            filename = Path(backup_dir / run_ids[0]).with_suffix(".pkl")
-            with open(filename, "rb") as f:
-                sim = dill.load(f)
-            return sim
+        possible_pickles = [Path(backup_dir / run_id).with_suffix(".pkl") for run_id in run_ids]
+        existing_pickles = [pickle for pickle in possible_pickles if pickle.exists()]
+        if exisiting_pickles:
+            last_pickle = max(existing_pickles, key=os.path.getctime)
+            if len(exisiting_pickles) > 1:
+                logger.warning(f"Multiple backups found for {job_parameters}. Using the most recent and deleting the rest.") 
+                for stale_file in exisiting_pickles - {last_pickle}:
+                    os.remove(stale_file)
+                with open(last_pickle, "rb") as f:
+                    sim = dill.load(f)
+                current_job_id = get_current_job().id
+                logger.info(f"Renaming backup file {last_pickle} to {current_job_id}.pkl")
+                os.rename(last_pickle, backup_dir / str(current_job_id)).with_suffix(".pkl")
+                return sim
     except (OSError, FileNotFoundError):
         return None
 

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -11,7 +11,7 @@ import json
 import math
 import os
 from pathlib import Path
-from time import time
+from time import time, sleep
 from traceback import format_exc
 from typing import Dict, Optional, Tuple, Union
 
@@ -89,11 +89,11 @@ def work_horse(job_parameters: dict) -> Tuple[pd.DataFrame, Dict[str, pd.DataFra
         step_size = pd.Timedelta(days=sim.configuration.time.step_size)
         num_steps = int(math.ceil((end_time - start_time) / step_size))
         logger.info(f"Starting main simulation loop with {num_steps} time steps")
+        backup_path = (job_parameters.backup_configuration["backup_dir"] / str(get_current_job().id)).with_suffix(".pkl")
+        logger.info(f"backup path: {backup_path}")
         sim.run(
-            sim,
             backup_freq=job_parameters.backup_configuration["backup_freq"],
-            backup_path=job_parameters.backup_configuration["backup_dir"]
-            / str(get_current_job().id).with_suffix(".pkl"),
+            backup_path=(job_parameters.backup_configuration["backup_dir"] / str(get_current_job().id)).with_suffix(".pkl"),
         )
         event["results_start"] = time()
         exec_time["main_loop_minutes"] = (
@@ -253,9 +253,12 @@ def get_backup(job_parameters: JobParameters) -> Optional[SimulationContext]:
                 sim = dill.load(f)
             current_job_id = get_current_job().id
             logger.info(f"Renaming backup file {last_pickle} to {current_job_id}.pkl")
-            os.rename(last_pickle, (backup_dir / str(current_job_id)).with_suffix(".pkl"))
+            if job_parameters.backup_configuration["backup_freq"] is not None:
+                # Sleep to prevent FS latency when loading the pickle
+                sleep(5)
+                os.rename(last_pickle, (backup_dir / str(current_job_id)).with_suffix(".pkl"))
             return sim
-    except (OSError, FileNotFoundError):
+    except (OSError, FileNotFoundError, EOFError):
         return None
 
 

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -115,6 +115,7 @@ def work_horse(job_parameters: dict) -> Tuple[pd.DataFrame, Dict[str, pd.DataFra
         do_sim_epilogue(start_snapshot, end_snapshot, event, exec_time, job_parameters)
         results = sim.get_results()  # Dict[measure, results dataframe]
         finished_results_metadata = format_and_record_details(job_parameters, results)
+        remove_backups(job_parameters)
 
         return finished_results_metadata, results
 
@@ -264,3 +265,12 @@ def get_backup(job_parameters: JobParameters) -> Optional[SimulationContext]:
                 sim = dill.load(f)
             return sim
     return None
+
+
+def remove_backups(job_parameters) -> None:
+    backup_dir = job_parameters.backup_configuration["backup_dir"]
+    backup_path = (backup_dir / str(get_current_job().id)).with_suffix(".pkl")
+    try:
+        os.remove(backup_path)
+    except FileNotFoundError:
+        pass

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -247,7 +247,7 @@ def get_backup(job_parameters: JobParameters) -> Optional[SimulationContext]:
                 logger.warning(
                     f"Multiple backups found for {job_parameters}. Using the most recent and deleting the rest."
                 )
-                for stale_file in existing_pickles - {last_pickle}:
+                for stale_file in set(existing_pickles) - {last_pickle}:
                     os.remove(stale_file)
             with open(last_pickle, "rb") as f:
                 sim = dill.load(f)

--- a/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
+++ b/src/vivarium_cluster_tools/psimulate/worker/vivarium_work_horse.py
@@ -259,7 +259,7 @@ def get_backup(job_parameters: JobParameters) -> Optional[SimulationContext]:
                 sleep(5)
                 os.rename(last_pickle, (backup_dir / str(current_job_id)).with_suffix(".pkl"))
             return sim
-    except OSError, FileNotFoundError:
+    except (OSError, FileNotFoundError):
         logger.info("Missing backup or backup directory. Restarting simulation from beginning.")
         return None
     except Exception as e:

--- a/tests/psimulate/redis_dbs/test_registry.py
+++ b/tests/psimulate/redis_dbs/test_registry.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 from vivarium_cluster_tools.psimulate.redis_dbs.registry import RegistryManager
@@ -20,3 +22,53 @@ def test_allocate_jobs(mocker, num_queues, num_jobs):
         this_layer = {queue[i]["job"] for queue in jobs_by_queue if len(queue) > i}
         next_layer = {queue[i + 1]["job"] for queue in jobs_by_queue if len(queue) > i + 1}
         assert max(this_layer) < min(next_layer)
+
+
+def create_mock_job(job_id, job_parameters):
+    mock_job = MagicMock()
+    mock_job.id = job_id
+    mock_job.kwargs = {"job_parameters": job_parameters}
+    return mock_job
+
+
+@pytest.fixture
+def mock_registry_manager():
+    # Mock the QueueManager used within RegistryManager
+    with patch(
+        "vivarium_cluster_tools.psimulate.redis_dbs.registry.QueueManager"
+    ) as MockQueueManager:
+        # Create mock jobs for each QueueManager
+        mock_jobs_list_1 = [
+            create_mock_job(1, "parameters1"),
+            create_mock_job(2, "parameters2"),
+        ]
+        mock_jobs_list_2 = [
+            create_mock_job(3, "parameters3"),
+            create_mock_job(4, "parameters4"),
+        ]
+
+        # Mock instances of QueueManager and their _queue.jobs to return the mock jobs
+        mock_queue_manager_instance_1 = MagicMock()
+        mock_queue_manager_instance_1._queue.jobs = mock_jobs_list_1
+
+        mock_queue_manager_instance_2 = MagicMock()
+        mock_queue_manager_instance_2._queue.jobs = mock_jobs_list_2
+
+        # Assuming RegistryManager initializes two QueueManagers internally
+        MockQueueManager.side_effect = [
+            mock_queue_manager_instance_1,
+            mock_queue_manager_instance_2,
+        ]
+
+        # Initialize your RegistryManager with mocked QueueManagers
+        manager = RegistryManager([("queue_0", 0), ("queue_1", 0)], 4, 0)
+
+        return manager
+
+
+def test_registry_manager_get_params_by_job(mock_registry_manager):
+    params_by_job = mock_registry_manager.get_params_by_job()
+    assert params_by_job[1] == "parameters1"
+    assert params_by_job[2] == "parameters2"
+    assert params_by_job[3] == "parameters3"
+    assert params_by_job[4] == "parameters4"

--- a/tests/psimulate/test_appending_perf_logs.py
+++ b/tests/psimulate/test_appending_perf_logs.py
@@ -79,6 +79,8 @@ def get_output_paths_from_output_directory(output_directory):
         branches=output_directory / "branches.yaml",
         finished_sim_metadata=output_directory / "finished_sim_metadata.csv",
         results_dir=output_directory / "results",
+        backup_dir=output_directory / "sim_backups",
+        backup_metadata_path=output_directory / "sim_backups" / "backup_metadata.csv",
     )
 
     return output_paths

--- a/tests/psimulate/test_runner.py
+++ b/tests/psimulate/test_runner.py
@@ -1,13 +1,34 @@
 import pandas as pd
 import pytest
+from pandas.testing import assert_frame_equal
 
-from vivarium_cluster_tools.psimulate.runner import report_initial_status
+from vivarium_cluster_tools.psimulate.runner import (
+    report_initial_status,
+    write_backup_metadata,
+)
 
 
 def test_report_initial_status():
-
     number_existing_jobs = 10
     finished_sim_metadata = pd.DataFrame(index=range(number_existing_jobs))
     report_initial_status(number_existing_jobs, finished_sim_metadata, 100)
     with pytest.raises(RuntimeError, match="There are 1 jobs from the previous run"):
         report_initial_status(number_existing_jobs + 1, finished_sim_metadata, 100)
+
+
+def test_write_backup_metadata(tmp_path):
+    metadata_path = tmp_path / "metadata.csv"
+    parameters_by_job = {
+        "job": {
+            "input_draw": 1337,
+            "random_seed": 42,
+            "branch_configuration": {"category": {"detail": 9}},
+        }
+    }
+    write_backup_metadata(metadata_path, parameters_by_job)
+    assert metadata_path.exists()
+    metadata = pd.read_csv(metadata_path)
+    expected_df = pd.DataFrame(
+        {"input_draw": [1337], "random_seed": [42], "job_id": ["job"], "category.detail": [9]}
+    )
+    assert_frame_equal(metadata, expected_df)

--- a/tests/psimulate/test_runner.py
+++ b/tests/psimulate/test_runner.py
@@ -32,3 +32,24 @@ def test_write_backup_metadata(tmp_path):
         {"input_draw": [1337], "random_seed": [42], "job_id": ["job"], "category.detail": [9]}
     )
     assert_frame_equal(metadata, expected_df)
+
+    # Check that we append to the existing metadata
+    # upon second execution
+    append_parameters_by_job = {
+        "job2": {
+            "input_draw": 1338,
+            "random_seed": 43,
+            "branch_configuration": {"category": {"detail": 10}},
+        }
+    }
+    write_backup_metadata(metadata_path, append_parameters_by_job)
+    metadata = pd.read_csv(metadata_path)
+    expected_df = pd.DataFrame(
+        {
+            "input_draw": [1337, 1338],
+            "random_seed": [42, 43],
+            "job_id": ["job", "job2"],
+            "category.detail": [9, 10],
+        }
+    )
+    assert_frame_equal(metadata, expected_df)

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -53,7 +53,7 @@ def test_setup_sim(mocker):
 
 
 @pytest.mark.parametrize(
-    "make_dir,has_metadata_file,has_backup, multiple_backups",
+    "make_dir, has_metadata_file, has_backup, multiple_backups",
     [
         (False, False, False, False),
         (True, False, False, False),

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -80,6 +80,7 @@ def test_get_backup_null_result(
         random_seed=random_seed,
         results_path="~/tmp",
         backup_configuration={
+            "backup_freq": 300,
             "backup_dir": tmp_path / "backups",
             "backup_metadata_path": tmp_path / "backups" / "backup_metadata.csv",
         },

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -62,7 +62,7 @@ def test_setup_sim(mocker):
         (True, True, True, True),
     ],
 )
-def test_get_backup_null_result(
+def test_get_backup(
     mocker, tmp_path, make_dir, has_metadata_file, has_backup, multiple_backups
 ) -> None:
     mocker.patch(

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -5,7 +5,6 @@ import pytest
 from vivarium_cluster_tools.psimulate.jobs import JobParameters
 from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import (
     get_backup,
-    remove_backups,
     parameter_update_format,
     setup_sim,
 )
@@ -56,7 +55,7 @@ def test_setup_sim(mocker):
     "make_dir,has_metadata_file,has_backup",
     [(False, False, False), (True, False, False), (True, True, False), (True, True, True)],
 )
-def test_get_and_remove_backup(tmp_path, make_dir, has_metadata_file, has_backup):
+def test_backup_no_dir(tmp_path, make_dir, has_metadata_file, has_backup):
     input_draw = 1
     random_seed = 2
     branch_configuration = {"branch_key": "branch_value"}
@@ -88,16 +87,11 @@ def test_get_and_remove_backup(tmp_path, make_dir, has_metadata_file, has_backup
             metadata.to_csv(tmp_path / "backups" / "backup_metadata.csv", index=False)
 
     if make_dir and has_metadata_file and has_backup:
-        pickle_path = tmp_path / "backups" / f"{job_id}.pkl"
         pickle = [1, 2, 3, 4, 5]
-        with open(pickle_path, "wb") as f:
+        with open(tmp_path / "backups" / "job_id.pkl", "wb") as f:
             dill.dump(pickle, f)
         backup = get_backup(job_parameters)
         assert backup == pickle
-        # Check we can remove the backup
-        remove_backups(job_parameters)
-        assert not pickle_path.exists()
-        
     else:
         backup = get_backup(job_parameters)
         assert not backup

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -131,14 +131,12 @@ def test_get_backup_null_result(
         assert not backup
 
 
-def test_remove_backups(mocker, tmp_path) -> None:
-    mocker.patch(
-        "vivarium_cluster_tools.psimulate.worker.vivarium_work_horse.get_current_job",
-        return_value=mocker.Mock(id="job_id"),
-    )
+def test_remove_backups(tmp_path) -> None:
+    # Ensure deleting non-existent file does not raise an error
+    remove_backups(tmp_path / "job_id.pkl")
     # touch a file
     (tmp_path / "job_id.pkl").touch()
     assert (tmp_path / "job_id.pkl").exists()
     # remove the file
-    remove_backups(tmp_path)
+    remove_backups(tmp_path / "job_id.pkl")
     assert not (tmp_path / "job_id.pkl").exists()

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -5,6 +5,7 @@ import pytest
 from vivarium_cluster_tools.psimulate.jobs import JobParameters
 from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import (
     get_backup,
+    remove_backups,
     parameter_update_format,
     setup_sim,
 )
@@ -55,7 +56,7 @@ def test_setup_sim(mocker):
     "make_dir,has_metadata_file,has_backup",
     [(False, False, False), (True, False, False), (True, True, False), (True, True, True)],
 )
-def test_backup_no_dir(tmp_path, make_dir, has_metadata_file, has_backup):
+def test_get_and_remove_backup(tmp_path, make_dir, has_metadata_file, has_backup):
     input_draw = 1
     random_seed = 2
     branch_configuration = {"branch_key": "branch_value"}
@@ -87,11 +88,16 @@ def test_backup_no_dir(tmp_path, make_dir, has_metadata_file, has_backup):
             metadata.to_csv(tmp_path / "backups" / "backup_metadata.csv", index=False)
 
     if make_dir and has_metadata_file and has_backup:
+        pickle_path = tmp_path / "backups" / f"{job_id}.pkl"
         pickle = [1, 2, 3, 4, 5]
-        with open(tmp_path / "backups" / "job_id.pkl", "wb") as f:
+        with open(pickle_path, "wb") as f:
             dill.dump(pickle, f)
         backup = get_backup(job_parameters)
         assert backup == pickle
+        # Check we can remove the backup
+        remove_backups(job_parameters)
+        assert not pickle_path.exists()
+        
     else:
         backup = get_backup(job_parameters)
         assert not backup

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -56,7 +56,7 @@ def test_setup_sim(mocker):
     "make_dir,has_metadata_file,has_backup",
     [(False, False, False), (True, False, False), (True, True, False), (True, True, True)],
 )
-def test_get_and_remove_backup(mocker, tmp_path, make_dir, has_metadata_file, has_backup):
+def test_get_backup(tmp_path, make_dir, has_metadata_file, has_backup) -> None:
     input_draw = 1
     random_seed = 2
     branch_configuration = {"branch_key": "branch_value"}
@@ -94,14 +94,20 @@ def test_get_and_remove_backup(mocker, tmp_path, make_dir, has_metadata_file, ha
             dill.dump(pickle, f)
         backup = get_backup(job_parameters)
         assert backup == pickle
-        # Check we can remove the backup
-        mocker.patch(
-            "vivarium_cluster_tools.psimulate.worker.vivarium_work_horse.get_current_job",
-            return_value=mocker.Mock(id=job_id),
-        )
-        remove_backups(job_parameters)
-        assert not pickle_path.exists()
 
     else:
         backup = get_backup(job_parameters)
         assert not backup
+
+
+def test_remove_backups(mocker, tmp_path) -> None:
+    mocker.patch(
+        "vivarium_cluster_tools.psimulate.worker.vivarium_work_horse.get_current_job",
+        return_value=mocker.Mock(id="job_id"),
+    )
+    # touch a file
+    (tmp_path / "job_id.pkl").touch()
+    assert (tmp_path / "job_id.pkl").exists()
+    # remove the file
+    remove_backups(tmp_path)
+    assert not (tmp_path / "job_id.pkl").exists()

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -28,6 +28,7 @@ def test_setup_sim(mocker):
         input_draw=1,
         random_seed=2,
         results_path="~/tmp",
+        backup_configuration={},
         extras={},
     )
 

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -5,8 +5,8 @@ import pytest
 from vivarium_cluster_tools.psimulate.jobs import JobParameters
 from vivarium_cluster_tools.psimulate.worker.vivarium_work_horse import (
     get_backup,
-    remove_backups,
     parameter_update_format,
+    remove_backups,
     setup_sim,
 )
 

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -56,7 +56,11 @@ def test_setup_sim(mocker):
     "make_dir,has_metadata_file,has_backup",
     [(False, False, False), (True, False, False), (True, True, False), (True, True, True)],
 )
-def test_get_backup(tmp_path, make_dir, has_metadata_file, has_backup) -> None:
+def test_get_backup(mocker, tmp_path, make_dir, has_metadata_file, has_backup) -> None:
+    mocker.patch(
+        "vivarium_cluster_tools.psimulate.worker.vivarium_work_horse.get_current_job",
+        return_value=mocker.Mock(id="job_id_2"),
+    )
     input_draw = 1
     random_seed = 2
     branch_configuration = {"branch_key": "branch_value"}

--- a/tests/psimulate/worker/test_vivarium_work_horse.py
+++ b/tests/psimulate/worker/test_vivarium_work_horse.py
@@ -62,17 +62,17 @@ def test_setup_sim(mocker):
         (True, True, True, True),
     ],
 )
-def test_get_backup(
+def test_get_backup_null_result(
     mocker, tmp_path, make_dir, has_metadata_file, has_backup, multiple_backups
 ) -> None:
     mocker.patch(
         "vivarium_cluster_tools.psimulate.worker.vivarium_work_horse.get_current_job",
-        return_value=mocker.Mock(id="job_id_2"),
+        return_value=mocker.Mock(id="current_job"),
     )
     input_draw = 1
     random_seed = 2
     branch_configuration = {"branch_key": "branch_value"}
-    job_id = "job_id"
+    job_id = "prev_job"
     job_parameters = JobParameters(
         model_specification=None,
         branch_configuration=branch_configuration,
@@ -122,6 +122,8 @@ def test_get_backup(
         backup = get_backup(job_parameters)
         assert backup == pickle
         assert not (tmp_path / "backups" / "stale_job.pkl").exists()
+        assert not (tmp_path / "backups" / "prev_job.pkl").exists()
+        assert (tmp_path / "backups" / "current_job.pkl").exists()
 
     else:
         backup = get_backup(job_parameters)


### PR DESCRIPTION
## Add Simulation Backups to PSimulate
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
feature
- *JIRA issue*: [MIC-5203](https://jira.ihme.washington.edu/browse/MIC-5203)

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Add pickled simulation backups to Psimulate.
You can specify the pickling frequency and whether to create backups; backups generally live in a "sim_backups" directory under the results root. The backups are deleted once the simulation completes successfully.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
wrote some unit tests and did testing with MNCH Child to ensure results are reproducible, and backups are saved, restarted, and deleted as expected.

I'm not quite finished testing the deletion but I think it can still get a review in the meantime.