### PR TITLE
don't install vivarium inside vct package directory

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,10 +50,11 @@ jobs:
         if: env.upstream_exist == 'true'
         run: |
           echo "Cloning upstream branch: ${branch_name}"
+          pushd ..
           git clone --branch=${branch_name} https://github.com/ihmeuw/vivarium.git
           pushd vivarium
           pip install .
-          popd
+          popd && popd
       - name: Install dependencies
         run: |
           pip install .[dev]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,6 @@
 [tool.black]
 line_length = 94
-exclude = '''
-/(
-   vivarium
-)/
-
-'''
 
 [tool.isort]
 profile = "black"
-skip = ["vivarium"]
 known_third_party = ["vivarium"]


### PR DESCRIPTION
## Don't install vivarium inside VCT package directory
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: CI/infrastructure
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5209

### Changes and notes
- Don't install vivarium inside VCT package directory 

### Testing
CI works with upstream vivarium branch
