### PR TITLE
place upper bound on sphinx

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     ]
 
     doc_requirements = [
-        "sphinx>=4.0",
+        "sphinx>=4.0,<8.0.0",
         "sphinx-rtd-theme",
         "sphinx-click",
         "sphinx-autodoc-typehints",


### PR DESCRIPTION
## place upper bound on sphinx
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-XYZ

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
builds are failing because sphinx 8.0 was released and broke something. it also drops python 3.9 support. As discussed, just pin this below 8 for now.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

