### PR TITLE
Albrja/mic 5235/duplicated worker log

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.1.7 - 05/27/25**
+
+  - Feature: Remove duplicate log messages to main simulation log file
+
 **2.1.6 - 05/01/25**
 
   - Bugfix: Add sim verbosity click option to restart and expand commands

--- a/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
+++ b/src/vivarium_cluster_tools/psimulate/redis_dbs/registry.py
@@ -96,14 +96,8 @@ class QueueManager:
         )
         return results
 
-    def update_and_report(self) -> dict[str, int | float]:
+    def update(self) -> dict[str, int | float]:
         self._update_status()
-        template = (
-            f"Queue {self.name} - Total jobs: {{total}}, % Done: {{done:.2f}}% "
-            f"Pending: {{pending}}, Running: {{running}}, Failed: {{failed}}, Successful: {{successful}} "
-        )
-        if not (self.completed or self.failed):
-            self._logger.info(template.format(**self._status))
         return self._status
 
     def _update_status(self) -> None:
@@ -286,7 +280,7 @@ class RegistryManager:
     def update_and_report(self) -> dict[str, int | float]:
         status: dict[str, int | float] = defaultdict(int)
         for queue in self._queues:
-            queue_status = queue.update_and_report()
+            queue_status = queue.update()
             for k, v in queue_status.items():
                 status[k] += v
         status["done"] = status["successful"] / status["total"] * 100


### PR DESCRIPTION
## Albrja/mic 5235/duplicated worker log messages

### Remove duplicated log messages
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-5235

### Changes and notes
-removes duplicated log messates in QueueManager and RegistryManager

### Testing
-ran parallel simulation and duplicate messages were not there
