### PR TITLE
do not raise if artifact path is not privided via cli

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**2.1.19 - 09/23/25**
+
+  - Bugfix: do not raise if artifact path is not provided via command line
+
 **2.1.18 - 08/22/25**
 
   - Type-hint entire repository
@@ -25,7 +29,6 @@
 **2.1.12 - 06/11/25**
 
   - Move deprecated rtd for redis
-
 
 **2.1.11 - 06/11/25**
 

--- a/src/vivarium_cluster_tools/psimulate/paths.py
+++ b/src/vivarium_cluster_tools/psimulate/paths.py
@@ -203,8 +203,6 @@ class OutputPaths(NamedTuple):
 
         output_directory = result_directory
         if command == COMMANDS.run:
-            if input_artifact_path is None:
-                raise ValueError("Input artifact path is required for run command")
             model_name = get_output_model_name_string(
                 input_artifact_path, input_model_spec_path
             )


### PR DESCRIPTION
## Do not raise if artifact path is not privided via cli

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6441

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> A bad type hint in vivarium led to copilot thinking that artifact path
could not be None when it fact it could be.

The random test I updated started failing. It has nothing to do with the
scope of this PR other than I needed to get it to pass. Instead of just
increasing the allowable threshold, Rajan suggested I mock time.sleep
which worked wonderfully.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->

