### PR TITLE
Remove mortality component from tests

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.0.3 - 04/06/26**
+
+  - Bugfix: Remove mortality component from test model specifications.
+
 **3.0.2 - 04/01/26**
 
   - Hash result folder in job name to deduplicate simultaneous runs

--- a/README.rst
+++ b/README.rst
@@ -60,7 +60,6 @@ your original model specification looked something like
       vivarium_public_health:
         population:
           - BasePopulation()
-          - Mortality()
         disease.models:
           - SIS('lower_respiratory_infections')
       my_lri_intervention:

--- a/tests/psimulate/data/e2e_model_spec.yaml
+++ b/tests/psimulate/data/e2e_model_spec.yaml
@@ -6,8 +6,6 @@ components:
     vivarium.examples.disease_model:
         population:
             - BasePopulation()
-        mortality:
-            - Mortality()
         observer:
             - DeathsObserver()
 configuration:

--- a/tests/psimulate/data/e2e_model_spec_fail_once.yaml
+++ b/tests/psimulate/data/e2e_model_spec_fail_once.yaml
@@ -9,8 +9,6 @@ components:
     vivarium.examples.disease_model:
         population:
             - BasePopulation()
-        mortality:
-            - Mortality()
         observer:
             - DeathsObserver()
     vivarium_cluster_tools.testing.fail_once_component:

--- a/tests/psimulate/test_e2e.py
+++ b/tests/psimulate/test_e2e.py
@@ -44,8 +44,7 @@ _EXPECTED_TOTAL_JOBS = 4
 
 RESULTS_DIR = "/mnt/team/simulation_science/priv/engineering/tests/output/"
 
-# Don't enforce weekly run requirement during development
-pytestmark = [pytest.mark.cluster, pytest.mark.slow]
+pytestmark = [pytest.mark.cluster, pytest.mark.slow, pytest.mark.weekly]
 
 
 def _make_shared_tmp_dir() -> Path:


### PR DESCRIPTION
## Remove mortality component from tests
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6940

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
Since mortality moved to pop component, this fails the test
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
checked that e2e tests run and pass
