### PR TITLE
Base jobmon workflow timeout on runner node

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**3.1.2 - 04/24/26**
+**3.1.2 - 04/27/26**
 
 - Dynamically determine jobmon workflow timeout from time remaining on runner node
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,4 +1,4 @@
-**3.1.2 - 04/23/26**
+**3.1.2 - 04/24/26**
 
 - Dynamically determine jobmon workflow timeout from time remaining on runner node
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.1.2 - 04/23/26**
+
+- Dynamically determine jobmon workflow timeout from time remaining on runner node
+
 **3.1.1 - 04/22/26**
 
 - Remove hanging redis install in makefile

--- a/src/vivarium_cluster_tools/psimulate/cluster/__init__.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/__init__.py
@@ -16,5 +16,6 @@ from vivarium_cluster_tools.psimulate.cluster.cli_options import (
 )
 from vivarium_cluster_tools.psimulate.cluster.interface import (
     NativeSpecification,
+    get_runner_node_remaining_seconds,
     validate_cluster_environment,
 )

--- a/src/vivarium_cluster_tools/psimulate/cluster/__init__.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/__init__.py
@@ -16,6 +16,6 @@ from vivarium_cluster_tools.psimulate.cluster.cli_options import (
 )
 from vivarium_cluster_tools.psimulate.cluster.interface import (
     NativeSpecification,
-    get_runner_node_remaining_seconds,
+    get_workflow_timeout_seconds,
     validate_cluster_environment,
 )

--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -131,6 +131,16 @@ def get_workflow_timeout_seconds() -> int:
             f"Could not determine remaining SLURM time for job {job_id}: {e}"
         ) from e
 
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"squeue failed for SLURM job {job_id} "
+            f"(exit {result.returncode}): {result.stderr.strip()}"
+        )
+
+    stderr_output = result.stderr.strip()
+    if stderr_output:
+        logger.warning(f"squeue stderr for job {job_id}: {stderr_output}")
+
     if not remaining_str:
         raise RuntimeError(
             f"squeue returned no output for SLURM job {job_id}. "
@@ -172,8 +182,9 @@ def _parse_slurm_time(time_str: str) -> int:
     ValueError
         If ``time_str`` does not match a recognized SLURM time format.
     """
-    # Match optional "D-" prefix followed by colon-separated numeric fields.
-    if not re.fullmatch(r"(\d+-)?\d+(:\d+){0,2}", time_str):
+    # When a day prefix is present, squeue always uses D-HH:MM:SS.
+    # Without a day prefix the format is HH:MM:SS, MM:SS, or SS.
+    if not re.fullmatch(r"(\d+-\d+:\d+:\d+|\d+(:\d+){0,2})", time_str):
         raise ValueError(
             f"Unrecognized SLURM time format: '{time_str}'. "
             "Expected D-HH:MM:SS, HH:MM:SS, MM:SS, or SS."

--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -146,19 +146,19 @@ def get_runner_node_remaining_seconds() -> int:
             "Cannot determine remaining allocation time."
         )
 
-    remaining_seconds = _parse_slurm_time(remaining_str) - _SLURM_TIMEOUT_BUFFER_SECONDS
-    if remaining_seconds <= 0:
+    remaining_seconds = _parse_slurm_time(remaining_str)
+    workflow_seconds = remaining_seconds - _SLURM_TIMEOUT_BUFFER_SECONDS
+    if workflow_seconds <= 0:
         raise RuntimeError(
-            f"SLURM allocation has {remaining_str} remaining, which is less than "
-            f"the {_SLURM_TIMEOUT_BUFFER_SECONDS}s safety buffer. "
+            f"SLURM allocation has {remaining_str} ({remaining_seconds}s) remaining, "
+            f"which is less than the {_SLURM_TIMEOUT_BUFFER_SECONDS}s safety buffer. "
             "Not enough time to run a workflow."
         )
     logger.info(
-        f"Detected SLURM allocation with {remaining_str} remaining. "
-        f"Setting workflow timeout to {remaining_seconds}s "
-        f"({_SLURM_TIMEOUT_BUFFER_SECONDS}s buffer)."
+        f"Detected SLURM allocation with {remaining_str} ({remaining_seconds}s) remaining. "
+        f"Setting workflow timeout to {workflow_seconds}s ({_SLURM_TIMEOUT_BUFFER_SECONDS}s buffer)."
     )
-    return remaining_seconds
+    return workflow_seconds
 
 
 def _parse_slurm_time(time_str: str) -> int:

--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -7,8 +7,13 @@ Cluster Interface
 
 from __future__ import annotations
 
+import os
+import re
+import subprocess
 from pathlib import Path
 from typing import Any, NamedTuple
+
+from loguru import logger
 
 from vivarium_cluster_tools.psimulate.environment import ENV_VARIABLES
 
@@ -90,3 +95,113 @@ class NativeSpecification(NamedTuple):
             return int(m) * 60 + int(s)
         else:
             return int(parts[0])
+
+
+# Buffer in seconds to subtract from the remaining SLURM time so the jobmon
+# workflow shuts down cleanly before SLURM kills the runner node.
+_SLURM_TIMEOUT_BUFFER_SECONDS = 120
+
+
+def get_runner_node_remaining_seconds() -> int:
+    """Return the number of seconds remaining in the current SLURM runner node allocation.
+
+    The result includes a small buffer so that the workflow can shut down
+    gracefully before SLURM terminates the runner node.
+
+    Returns
+    -------
+        Remaining time in seconds (with buffer subtracted).
+
+    Raises
+    ------
+    RuntimeError
+        If ``SLURM_JOB_ID`` is not set, the remaining time is less than the safety
+        buffer, or the remaining time cannot be determined from ``squeue``.
+    """
+    job_id = os.environ.get("SLURM_JOB_ID")
+    if job_id is None:
+        raise RuntimeError(
+            "SLURM_JOB_ID is not set. psimulate must be run from within a "
+            "SLURM allocation (e.g. via srun)."
+        )
+
+    try:
+        # squeue -h -j <job_id> -o %L gives the remaining time as
+        # [D-]HH:MM:SS or "UNLIMITED".
+        result = subprocess.run(
+            ["squeue", "-h", "-j", job_id, "-o", "%L"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        remaining_str = result.stdout.strip()
+    except Exception as e:
+        raise RuntimeError(
+            f"Could not determine remaining SLURM time for job {job_id}: {e}"
+        ) from e
+
+    if not remaining_str:
+        raise RuntimeError(
+            f"squeue returned no output for SLURM job {job_id}. "
+            "Cannot determine remaining allocation time."
+        )
+
+    remaining_seconds = _parse_slurm_time(remaining_str) - _SLURM_TIMEOUT_BUFFER_SECONDS
+    if remaining_seconds <= 0:
+        raise RuntimeError(
+            f"SLURM allocation has {remaining_str} remaining, which is less than "
+            f"the {_SLURM_TIMEOUT_BUFFER_SECONDS}s safety buffer. "
+            "Not enough time to run a workflow."
+        )
+    logger.info(
+        f"Detected SLURM allocation with {remaining_str} remaining. "
+        f"Setting workflow timeout to {remaining_seconds}s "
+        f"({_SLURM_TIMEOUT_BUFFER_SECONDS}s buffer)."
+    )
+    return remaining_seconds
+
+
+def _parse_slurm_time(time_str: str) -> int:
+    """Parse a SLURM time string into seconds.
+
+    Handles the formats returned by ``squeue -o %L``:
+    ``SS``, ``MM:SS``, ``HH:MM:SS``, ``D-HH:MM:SS``.
+
+    Parameters
+    ----------
+    time_str
+        A SLURM time string.
+
+    Returns
+    -------
+        Total seconds represented by the time string.
+
+    Raises
+    ------
+    ValueError
+        If ``time_str`` does not match a recognized SLURM time format.
+    """
+    # Match optional "D-" prefix followed by colon-separated numeric fields.
+    if not re.fullmatch(r"(\d+-)?\d+(:\d+){0,2}", time_str):
+        raise ValueError(
+            f"Unrecognized SLURM time format: '{time_str}'. "
+            "Expected D-HH:MM:SS, HH:MM:SS, MM:SS, or SS."
+        )
+
+    if "-" in time_str:
+        days, hms = time_str.split("-", 1)
+    else:
+        days = "0"
+        hms = time_str
+
+    hms_parts = hms.split(":")
+    if len(hms_parts) == 3:
+        h, m, s = hms_parts
+    elif len(hms_parts) == 2:
+        m, s = hms_parts
+        h = "0"
+    else:
+        s = hms_parts[0]
+        h = "0"
+        m = "0"
+    return int(days) * 86400 + int(h) * 3600 + int(m) * 60 + int(s)

--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -86,15 +86,7 @@ class NativeSpecification(NamedTuple):
         -------
             Runtime in seconds.
         """
-        parts = runtime_str.split(":")
-        if len(parts) == 3:
-            h, m, s = parts
-            return int(h) * 3600 + int(m) * 60 + int(s)
-        elif len(parts) == 2:
-            m, s = parts
-            return int(m) * 60 + int(s)
-        else:
-            return int(parts[0])
+        return _parse_slurm_time(runtime_str)
 
 
 # Buffer in seconds to subtract from the remaining SLURM time so the jobmon
@@ -102,8 +94,8 @@ class NativeSpecification(NamedTuple):
 _SLURM_TIMEOUT_BUFFER_SECONDS = 120
 
 
-def get_runner_node_remaining_seconds() -> int:
-    """Return the number of seconds remaining in the current SLURM runner node allocation.
+def get_workflow_timeout_seconds() -> int:
+    """Get jobmon workflow's timeout in seconds.
 
     The result includes a small buffer so that the workflow can shut down
     gracefully before SLURM terminates the runner node.
@@ -126,8 +118,7 @@ def get_runner_node_remaining_seconds() -> int:
         )
 
     try:
-        # squeue -h -j <job_id> -o %L gives the remaining time as
-        # [D-]HH:MM:SS or "UNLIMITED".
+        # squeue -h -j <job_id> -o %L gives the remaining time as D-HH:MM:SS
         result = subprocess.run(
             ["squeue", "-h", "-j", job_id, "-o", "%L"],
             capture_output=True,

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -336,7 +336,7 @@ def main(
 
     # Match the workflow timeout to the remaining time on the SLURM runner
     # node so jobmon doesn't outlive (or underuse) the allocation.
-    seconds_until_timeout = cluster.get_runner_node_remaining_seconds()
+    seconds_until_timeout = cluster.get_workflow_timeout_seconds()
     wf_status = workflow.run(resume=restart, seconds_until_timeout=seconds_until_timeout)
 
     # Spit out a performance report for the workers.

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -334,7 +334,10 @@ def main(
     if monitoring_url:
         logger.info(f"Monitor progress at: {monitoring_url}")
 
-    wf_status = workflow.run(resume=restart)
+    # Match the workflow timeout to the remaining time on the SLURM runner
+    # node so jobmon doesn't outlive (or underuse) the allocation.
+    seconds_until_timeout = cluster.get_runner_node_remaining_seconds()
+    wf_status = workflow.run(resume=restart, seconds_until_timeout=seconds_until_timeout)
 
     # Spit out a performance report for the workers.
     try_run_vipin(output_paths)

--- a/tests/psimulate/cluster/test_interface.py
+++ b/tests/psimulate/cluster/test_interface.py
@@ -8,9 +8,10 @@ import pytest
 
 from vivarium_cluster_tools.psimulate.cluster import validate_cluster_environment
 from vivarium_cluster_tools.psimulate.cluster.interface import (
+    _SLURM_TIMEOUT_BUFFER_SECONDS,
     NativeSpecification,
     _parse_slurm_time,
-    get_runner_node_remaining_seconds,
+    get_workflow_timeout_seconds,
 )
 
 
@@ -164,6 +165,13 @@ class TestParseSlurmTime:
 class TestGetRunnerNodeRemainingSeconds:
     """Tests for get_runner_node_remaining_seconds."""
 
+    def convert_seconds_to_time_str(self, seconds: int) -> str:
+        """Helper to convert seconds to HH:MM:SS format."""
+        h = seconds // 3600
+        m = (seconds % 3600) // 60
+        s = seconds % 60
+        return f"{h:02d}:{m:02d}:{s:02d}"
+
     @pytest.fixture(autouse=True)
     def _set_slurm_job_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Set SLURM_JOB_ID for all tests; individual tests can override."""
@@ -173,21 +181,21 @@ class TestGetRunnerNodeRemainingSeconds:
         """Raise when not inside a SLURM allocation."""
         monkeypatch.delenv("SLURM_JOB_ID")
         with pytest.raises(RuntimeError, match="SLURM_JOB_ID is not set"):
-            get_runner_node_remaining_seconds()
+            get_workflow_timeout_seconds()
 
     def test_returns_remaining_minus_buffer(self) -> None:
         """Return remaining seconds minus the safety buffer."""
         completed = _make_squeue_result("10:00:00")
         with patch("subprocess.run", return_value=completed):
-            result = get_runner_node_remaining_seconds()
-        assert result == 36000 - 120
+            result = get_workflow_timeout_seconds()
+        assert result == 36000 - _SLURM_TIMEOUT_BUFFER_SECONDS
 
     def test_raises_for_unlimited(self) -> None:
         """Raise when SLURM reports UNLIMITED time."""
         completed = _make_squeue_result("UNLIMITED")
         with patch("subprocess.run", return_value=completed):
             with pytest.raises(ValueError, match="Unrecognized SLURM time format"):
-                get_runner_node_remaining_seconds()
+                get_workflow_timeout_seconds()
 
     @pytest.mark.parametrize(
         "bad_value",
@@ -199,27 +207,37 @@ class TestGetRunnerNodeRemainingSeconds:
         completed = _make_squeue_result(bad_value)
         with patch("subprocess.run", return_value=completed):
             with pytest.raises(ValueError, match="Unrecognized SLURM time format"):
-                get_runner_node_remaining_seconds()
+                get_workflow_timeout_seconds()
 
     def test_raises_when_remaining_less_than_buffer(self) -> None:
         """Raise when remaining time is less than the safety buffer."""
-        completed = _make_squeue_result("00:01:00")  # 60 seconds < 120 buffer
+        remaining_seconds = _SLURM_TIMEOUT_BUFFER_SECONDS - 1
+        completed = _make_squeue_result(self.convert_seconds_to_time_str(remaining_seconds))
         with patch("subprocess.run", return_value=completed):
             with pytest.raises(RuntimeError, match="Not enough time"):
-                get_runner_node_remaining_seconds()
+                get_workflow_timeout_seconds()
 
     def test_raises_when_remaining_exactly_equals_buffer(self) -> None:
         """Raise when remaining time exactly equals the safety buffer."""
-        completed = _make_squeue_result("00:02:00")  # 120 seconds == buffer
+        # Convert the seconds buffer to HH:MM:SS format
+        completed = _make_squeue_result(
+            self.convert_seconds_to_time_str(_SLURM_TIMEOUT_BUFFER_SECONDS)
+        )
         with patch("subprocess.run", return_value=completed):
             with pytest.raises(RuntimeError, match="Not enough time"):
-                get_runner_node_remaining_seconds()
+                get_workflow_timeout_seconds()
+
+    def test_returns_one_second_when_just_above_buffer(self) -> None:
+        remaining_seconds = _SLURM_TIMEOUT_BUFFER_SECONDS + 1
+        completed = _make_squeue_result(self.convert_seconds_to_time_str(remaining_seconds))
+        with patch("subprocess.run", return_value=completed):
+            assert get_workflow_timeout_seconds() == 1
 
     def test_raises_on_subprocess_error(self) -> None:
         """Raise when squeue fails."""
         with patch("subprocess.run", side_effect=FileNotFoundError("squeue not found")):
             with pytest.raises(RuntimeError, match="Could not determine"):
-                get_runner_node_remaining_seconds()
+                get_workflow_timeout_seconds()
 
     def test_raises_on_subprocess_timeout(self) -> None:
         """Raise when squeue times out."""
@@ -228,29 +246,28 @@ class TestGetRunnerNodeRemainingSeconds:
             side_effect=subprocess.TimeoutExpired(cmd="squeue", timeout=10),
         ):
             with pytest.raises(RuntimeError, match="Could not determine"):
-                get_runner_node_remaining_seconds()
+                get_workflow_timeout_seconds()
 
     def test_raises_on_empty_squeue_output(self) -> None:
         """Raise when squeue returns empty output."""
         completed = _make_squeue_result("")
         with patch("subprocess.run", return_value=completed):
             with pytest.raises(RuntimeError, match="no output"):
-                get_runner_node_remaining_seconds()
+                get_workflow_timeout_seconds()
 
     def test_handles_day_format(self) -> None:
         """Handle D-HH:MM:SS format from squeue."""
         completed = _make_squeue_result("1-12:00:00")
         with patch("subprocess.run", return_value=completed):
-            result = get_runner_node_remaining_seconds()
-        expected = (86400 + 12 * 3600) - 120
+            result = get_workflow_timeout_seconds()
+        expected = (86400 + 12 * 3600) - _SLURM_TIMEOUT_BUFFER_SECONDS
         assert result == expected
 
 
 def _make_squeue_result(time_str: str) -> Any:
     """Create a mock subprocess.CompletedProcess for squeue output."""
-    from subprocess import CompletedProcess
 
-    return CompletedProcess(
+    return subprocess.CompletedProcess(
         args=["squeue", "-h", "-j", "12345", "-o", "%L"],
         returncode=0,
         stdout=f"{time_str}\n",

--- a/tests/psimulate/cluster/test_interface.py
+++ b/tests/psimulate/cluster/test_interface.py
@@ -155,7 +155,7 @@ class TestParseSlurmTime:
 
     @pytest.mark.parametrize(
         "bad_value",
-        ["UNLIMITED", "NOT_SET", "abc", "1:2:3:4", "--:--", ""],
+        ["UNLIMITED", "NOT_SET", "abc", "1:2:3:4", "--:--", "", "1-30", "1-10:30"],
     )
     def test_parse_slurm_time_rejects_invalid(self, bad_value: str) -> None:
         with pytest.raises(ValueError, match="Unrecognized SLURM time format"):
@@ -186,14 +186,20 @@ class TestGetRunnerNodeRemainingSeconds:
     def test_returns_remaining_minus_buffer(self) -> None:
         """Return remaining seconds minus the safety buffer."""
         completed = _make_squeue_result("10:00:00")
-        with patch("subprocess.run", return_value=completed):
+        with patch(
+            "vivarium_cluster_tools.psimulate.cluster.interface.subprocess.run",
+            return_value=completed,
+        ):
             result = get_workflow_timeout_seconds()
         assert result == 36000 - _SLURM_TIMEOUT_BUFFER_SECONDS
 
     def test_raises_for_unlimited(self) -> None:
         """Raise when SLURM reports UNLIMITED time."""
         completed = _make_squeue_result("UNLIMITED")
-        with patch("subprocess.run", return_value=completed):
+        with patch(
+            "vivarium_cluster_tools.psimulate.cluster.interface.subprocess.run",
+            return_value=completed,
+        ):
             with pytest.raises(ValueError, match="Unrecognized SLURM time format"):
                 get_workflow_timeout_seconds()
 
@@ -205,7 +211,10 @@ class TestGetRunnerNodeRemainingSeconds:
     def test_raises_for_non_time_strings(self, bad_value: str) -> None:
         """Raise when squeue returns a non-numeric time string."""
         completed = _make_squeue_result(bad_value)
-        with patch("subprocess.run", return_value=completed):
+        with patch(
+            "vivarium_cluster_tools.psimulate.cluster.interface.subprocess.run",
+            return_value=completed,
+        ):
             with pytest.raises(ValueError, match="Unrecognized SLURM time format"):
                 get_workflow_timeout_seconds()
 
@@ -213,7 +222,10 @@ class TestGetRunnerNodeRemainingSeconds:
         """Raise when remaining time is less than the safety buffer."""
         remaining_seconds = _SLURM_TIMEOUT_BUFFER_SECONDS - 1
         completed = _make_squeue_result(self.convert_seconds_to_time_str(remaining_seconds))
-        with patch("subprocess.run", return_value=completed):
+        with patch(
+            "vivarium_cluster_tools.psimulate.cluster.interface.subprocess.run",
+            return_value=completed,
+        ):
             with pytest.raises(RuntimeError, match="Not enough time"):
                 get_workflow_timeout_seconds()
 
@@ -223,19 +235,28 @@ class TestGetRunnerNodeRemainingSeconds:
         completed = _make_squeue_result(
             self.convert_seconds_to_time_str(_SLURM_TIMEOUT_BUFFER_SECONDS)
         )
-        with patch("subprocess.run", return_value=completed):
+        with patch(
+            "vivarium_cluster_tools.psimulate.cluster.interface.subprocess.run",
+            return_value=completed,
+        ):
             with pytest.raises(RuntimeError, match="Not enough time"):
                 get_workflow_timeout_seconds()
 
     def test_returns_one_second_when_just_above_buffer(self) -> None:
         remaining_seconds = _SLURM_TIMEOUT_BUFFER_SECONDS + 1
         completed = _make_squeue_result(self.convert_seconds_to_time_str(remaining_seconds))
-        with patch("subprocess.run", return_value=completed):
+        with patch(
+            "vivarium_cluster_tools.psimulate.cluster.interface.subprocess.run",
+            return_value=completed,
+        ):
             assert get_workflow_timeout_seconds() == 1
 
     def test_raises_on_subprocess_error(self) -> None:
         """Raise when squeue fails."""
-        with patch("subprocess.run", side_effect=FileNotFoundError("squeue not found")):
+        with patch(
+            "vivarium_cluster_tools.psimulate.cluster.interface.subprocess.run",
+            side_effect=FileNotFoundError("squeue not found"),
+        ):
             with pytest.raises(RuntimeError, match="Could not determine"):
                 get_workflow_timeout_seconds()
 
@@ -248,17 +269,38 @@ class TestGetRunnerNodeRemainingSeconds:
             with pytest.raises(RuntimeError, match="Could not determine"):
                 get_workflow_timeout_seconds()
 
+    def test_raises_on_nonzero_returncode(self) -> None:
+        """Raise when squeue exits with a non-zero return code."""
+        completed = subprocess.CompletedProcess(
+            args=["squeue", "-h", "-j", "12345", "-o", "%L"],
+            returncode=1,  # non-zero return code
+            stdout="",
+            stderr="slurm_load_jobs error: Invalid job id specified\n",
+        )
+        with patch(
+            "vivarium_cluster_tools.psimulate.cluster.interface.subprocess.run",
+            return_value=completed,
+        ):
+            with pytest.raises(RuntimeError, match="squeue failed"):
+                get_workflow_timeout_seconds()
+
     def test_raises_on_empty_squeue_output(self) -> None:
         """Raise when squeue returns empty output."""
         completed = _make_squeue_result("")
-        with patch("subprocess.run", return_value=completed):
+        with patch(
+            "vivarium_cluster_tools.psimulate.cluster.interface.subprocess.run",
+            return_value=completed,
+        ):
             with pytest.raises(RuntimeError, match="no output"):
                 get_workflow_timeout_seconds()
 
     def test_handles_day_format(self) -> None:
         """Handle D-HH:MM:SS format from squeue."""
         completed = _make_squeue_result("1-12:00:00")
-        with patch("subprocess.run", return_value=completed):
+        with patch(
+            "vivarium_cluster_tools.psimulate.cluster.interface.subprocess.run",
+            return_value=completed,
+        ):
             result = get_workflow_timeout_seconds()
         expected = (86400 + 12 * 3600) - _SLURM_TIMEOUT_BUFFER_SECONDS
         assert result == expected

--- a/tests/psimulate/cluster/test_interface.py
+++ b/tests/psimulate/cluster/test_interface.py
@@ -1,11 +1,17 @@
 import socket
+import subprocess
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
 from vivarium_cluster_tools.psimulate.cluster import validate_cluster_environment
-from vivarium_cluster_tools.psimulate.cluster.interface import NativeSpecification
+from vivarium_cluster_tools.psimulate.cluster.interface import (
+    NativeSpecification,
+    _parse_slurm_time,
+    get_runner_node_remaining_seconds,
+)
 
 
 @pytest.fixture(
@@ -124,3 +130,129 @@ class TestNativeSpecification:
     )
     def test_runtime_to_seconds(self, runtime_str: str, expected: int) -> None:
         assert NativeSpecification._runtime_to_seconds(runtime_str) == expected
+
+
+class TestParseSlurmTime:
+    """Tests for _parse_slurm_time."""
+
+    @pytest.mark.parametrize(
+        "time_str, expected",
+        [
+            ("10:00:00", 36000),
+            ("1:30:00", 5400),
+            ("00:05:00", 300),
+            ("5:00", 300),
+            ("59", 59),
+            ("0:59", 59),
+            ("1-00:00:00", 86400),
+            ("2-12:00:00", 2 * 86400 + 12 * 3600),
+            ("1-01:30:45", 86400 + 3600 + 30 * 60 + 45),
+        ],
+    )
+    def test_parse_slurm_time(self, time_str: str, expected: int) -> None:
+        assert _parse_slurm_time(time_str) == expected
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        ["UNLIMITED", "NOT_SET", "abc", "1:2:3:4", "--:--", ""],
+    )
+    def test_parse_slurm_time_rejects_invalid(self, bad_value: str) -> None:
+        with pytest.raises(ValueError, match="Unrecognized SLURM time format"):
+            _parse_slurm_time(bad_value)
+
+
+class TestGetRunnerNodeRemainingSeconds:
+    """Tests for get_runner_node_remaining_seconds."""
+
+    @pytest.fixture(autouse=True)
+    def _set_slurm_job_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Set SLURM_JOB_ID for all tests; individual tests can override."""
+        monkeypatch.setenv("SLURM_JOB_ID", "12345")
+
+    def test_no_slurm_job_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Raise when not inside a SLURM allocation."""
+        monkeypatch.delenv("SLURM_JOB_ID")
+        with pytest.raises(RuntimeError, match="SLURM_JOB_ID is not set"):
+            get_runner_node_remaining_seconds()
+
+    def test_returns_remaining_minus_buffer(self) -> None:
+        """Return remaining seconds minus the safety buffer."""
+        completed = _make_squeue_result("10:00:00")
+        with patch("subprocess.run", return_value=completed):
+            result = get_runner_node_remaining_seconds()
+        assert result == 36000 - 120
+
+    def test_raises_for_unlimited(self) -> None:
+        """Raise when SLURM reports UNLIMITED time."""
+        completed = _make_squeue_result("UNLIMITED")
+        with patch("subprocess.run", return_value=completed):
+            with pytest.raises(ValueError, match="Unrecognized SLURM time format"):
+                get_runner_node_remaining_seconds()
+
+    @pytest.mark.parametrize(
+        "bad_value",
+        ["NOT_SET", "INVALID", "abc:def:ghi", "--:--:--", "inf"],
+        ids=["NOT_SET", "INVALID", "non-numeric-colons", "dashes", "inf"],
+    )
+    def test_raises_for_non_time_strings(self, bad_value: str) -> None:
+        """Raise when squeue returns a non-numeric time string."""
+        completed = _make_squeue_result(bad_value)
+        with patch("subprocess.run", return_value=completed):
+            with pytest.raises(ValueError, match="Unrecognized SLURM time format"):
+                get_runner_node_remaining_seconds()
+
+    def test_raises_when_remaining_less_than_buffer(self) -> None:
+        """Raise when remaining time is less than the safety buffer."""
+        completed = _make_squeue_result("00:01:00")  # 60 seconds < 120 buffer
+        with patch("subprocess.run", return_value=completed):
+            with pytest.raises(RuntimeError, match="Not enough time"):
+                get_runner_node_remaining_seconds()
+
+    def test_raises_when_remaining_exactly_equals_buffer(self) -> None:
+        """Raise when remaining time exactly equals the safety buffer."""
+        completed = _make_squeue_result("00:02:00")  # 120 seconds == buffer
+        with patch("subprocess.run", return_value=completed):
+            with pytest.raises(RuntimeError, match="Not enough time"):
+                get_runner_node_remaining_seconds()
+
+    def test_raises_on_subprocess_error(self) -> None:
+        """Raise when squeue fails."""
+        with patch("subprocess.run", side_effect=FileNotFoundError("squeue not found")):
+            with pytest.raises(RuntimeError, match="Could not determine"):
+                get_runner_node_remaining_seconds()
+
+    def test_raises_on_subprocess_timeout(self) -> None:
+        """Raise when squeue times out."""
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="squeue", timeout=10),
+        ):
+            with pytest.raises(RuntimeError, match="Could not determine"):
+                get_runner_node_remaining_seconds()
+
+    def test_raises_on_empty_squeue_output(self) -> None:
+        """Raise when squeue returns empty output."""
+        completed = _make_squeue_result("")
+        with patch("subprocess.run", return_value=completed):
+            with pytest.raises(RuntimeError, match="no output"):
+                get_runner_node_remaining_seconds()
+
+    def test_handles_day_format(self) -> None:
+        """Handle D-HH:MM:SS format from squeue."""
+        completed = _make_squeue_result("1-12:00:00")
+        with patch("subprocess.run", return_value=completed):
+            result = get_runner_node_remaining_seconds()
+        expected = (86400 + 12 * 3600) - 120
+        assert result == expected
+
+
+def _make_squeue_result(time_str: str) -> Any:
+    """Create a mock subprocess.CompletedProcess for squeue output."""
+    from subprocess import CompletedProcess
+
+    return CompletedProcess(
+        args=["squeue", "-h", "-j", "12345", "-o", "%L"],
+        returncode=0,
+        stdout=f"{time_str}\n",
+        stderr="",
+    )


### PR DESCRIPTION
## Base jobmon workflow timeout on runner node
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6937

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 

Calculates the timeout time as 2 minutes less than the runner node's remaining
time and passes that into the workflow run call.

### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
added unit tests
manually tested `psimulate run` and `psimulate restart`
