### PR TITLE
Make VCT require slurm node resources weekly

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+**3.1.3 - 05/07/26**
+
+- Set VCT to run E2E tests on slurm weekly
+
 **3.1.2 - 04/27/26**
 
 - Dynamically determine jobmon workflow timeout from time remaining on runner node

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -34,5 +34,5 @@ reusable_pipeline(
       // for subsequent scheduled builds to run.
       "main"
     ],
-    requires_slurm: true, 
+    requires_slurm: "weekly", 
 )

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ Note that updating the shared repo will take affect on the next pipeline invocat
 @Library("get_vbu_version@main") _
 
 // Load the full vivarium_build_utils library at the expected version
-library("vivarium_build_utils@pnast/feature/mic-7051-weekly-override")
+library("vivarium_build_utils@${get_vbu_version()}")
 
 reusable_pipeline(
     scheduled_branches: [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ Note that updating the shared repo will take affect on the next pipeline invocat
 @Library("get_vbu_version@main") _
 
 // Load the full vivarium_build_utils library at the expected version
-library("vivarium_build_utils@pnast/hotfix/mic-7051-weekly")
+library("vivarium_build_utils@pnast/feature/mic-7051-weekly-override")
 
 reusable_pipeline(
     scheduled_branches: [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ Note that updating the shared repo will take affect on the next pipeline invocat
 @Library("get_vbu_version@main") _
 
 // Load the full vivarium_build_utils library at the expected version
-library("vivarium_build_utils@${get_vbu_version()}")
+library("vivarium_build_utils@pnast/hotfix/3.2.2")
 
 reusable_pipeline(
     scheduled_branches: [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ Note that updating the shared repo will take affect on the next pipeline invocat
 @Library("get_vbu_version@main") _
 
 // Load the full vivarium_build_utils library at the expected version
-library("vivarium_build_utils@${get_vbu_version()}")
+library("vivarium_build_utils@pnast/hotfix/mic-7051-weekly")
 
 reusable_pipeline(
     scheduled_branches: [

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,7 @@ Note that updating the shared repo will take affect on the next pipeline invocat
 @Library("get_vbu_version@main") _
 
 // Load the full vivarium_build_utils library at the expected version
-library("vivarium_build_utils@pnast/hotfix/3.2.2")
+library("vivarium_build_utils@${get_vbu_version()}")
 
 reusable_pipeline(
     scheduled_branches: [

--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -107,15 +107,15 @@ def get_workflow_timeout_seconds() -> int:
     Raises
     ------
     RuntimeError
-        If ``SLURM_JOB_ID`` is not set, the remaining time is less than the safety
+        If the remaining time is less than the safety
         buffer, or the remaining time cannot be determined from ``squeue``.
     """
     job_id = os.environ.get("SLURM_JOB_ID")
     if job_id is None:
-        raise RuntimeError(
-            "SLURM_JOB_ID is not set. psimulate must be run from within a "
-            "SLURM allocation (e.g. via srun)."
-        )
+        logger.info("SLURM_JOB_ID is unset. The workflow is likely being run"
+                    "from a SLURM-capable host without an explicit resource allocation"
+                    "e.g. Jenkins. The timeout will be set to the default 36000 seconds (10 hours).")
+        return 36000
 
     try:
         # squeue -h -j <job_id> -o %L gives the remaining time as D-HH:MM:SS

--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -89,16 +89,12 @@ class NativeSpecification(NamedTuple):
         return _parse_slurm_time(runtime_str)
 
 
-# Default timeout in seconds for the jobmon workflow when no SLURM allocation
-# is detected (e.g. running from Jenkins).  10 hours.
-JOBMON_DEFAULT_TIMEOUT = 36000
-
 # Buffer in seconds to subtract from the remaining SLURM time so the jobmon
 # workflow shuts down cleanly before SLURM kills the runner node.
 _SLURM_TIMEOUT_BUFFER_SECONDS = 120
 
 
-def get_workflow_timeout_seconds() -> int:
+def get_workflow_timeout_seconds() -> int | None:
     """Get jobmon workflow's timeout in seconds.
 
     The result includes a small buffer so that the workflow can shut down
@@ -106,7 +102,9 @@ def get_workflow_timeout_seconds() -> int:
 
     Returns
     -------
-        Remaining time in seconds (with buffer subtracted).
+        Remaining time in seconds (with buffer subtracted), or ``None`` if
+        there is no SLURM allocation (in which case Jobmon's built-in default
+        timeout is used).
 
     Raises
     ------
@@ -117,11 +115,11 @@ def get_workflow_timeout_seconds() -> int:
     job_id = os.environ.get("SLURM_JOB_ID")
     if job_id is None:
         logger.info(
-            "SLURM_JOB_ID is unset. The workflow is likely being run"
-            "from a SLURM-capable host without an explicit resource allocation"
-            f"e.g. Jenkins. The timeout will be set to the default {JOBMON_DEFAULT_TIMEOUT} seconds."
+            "SLURM_JOB_ID is unset. The workflow is likely being run "
+            "from a SLURM-capable host without an explicit resource allocation "
+            "e.g. Jenkins. Deferring to Jobmon's default timeout."
         )
-        return JOBMON_DEFAULT_TIMEOUT
+        return None
 
     try:
         # squeue -h -j <job_id> -o %L gives the remaining time as D-HH:MM:SS

--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -89,6 +89,10 @@ class NativeSpecification(NamedTuple):
         return _parse_slurm_time(runtime_str)
 
 
+# Default timeout in seconds for the jobmon workflow when no SLURM allocation
+# is detected (e.g. running from Jenkins).  10 hours.
+JOBMON_DEFAULT_TIMEOUT = 36000
+
 # Buffer in seconds to subtract from the remaining SLURM time so the jobmon
 # workflow shuts down cleanly before SLURM kills the runner node.
 _SLURM_TIMEOUT_BUFFER_SECONDS = 120
@@ -115,9 +119,9 @@ def get_workflow_timeout_seconds() -> int:
         logger.info(
             "SLURM_JOB_ID is unset. The workflow is likely being run"
             "from a SLURM-capable host without an explicit resource allocation"
-            "e.g. Jenkins. The timeout will be set to the default 36000 seconds (10 hours)."
+            f"e.g. Jenkins. The timeout will be set to the default {JOBMON_DEFAULT_TIMEOUT} seconds."
         )
-        return 36000
+        return JOBMON_DEFAULT_TIMEOUT
 
     try:
         # squeue -h -j <job_id> -o %L gives the remaining time as D-HH:MM:SS

--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -112,9 +112,11 @@ def get_workflow_timeout_seconds() -> int:
     """
     job_id = os.environ.get("SLURM_JOB_ID")
     if job_id is None:
-        logger.info("SLURM_JOB_ID is unset. The workflow is likely being run"
-                    "from a SLURM-capable host without an explicit resource allocation"
-                    "e.g. Jenkins. The timeout will be set to the default 36000 seconds (10 hours).")
+        logger.info(
+            "SLURM_JOB_ID is unset. The workflow is likely being run"
+            "from a SLURM-capable host without an explicit resource allocation"
+            "e.g. Jenkins. The timeout will be set to the default 36000 seconds (10 hours)."
+        )
         return 36000
 
     try:

--- a/src/vivarium_cluster_tools/psimulate/runner.py
+++ b/src/vivarium_cluster_tools/psimulate/runner.py
@@ -337,7 +337,10 @@ def main(
     # Match the workflow timeout to the remaining time on the SLURM runner
     # node so jobmon doesn't outlive (or underuse) the allocation.
     seconds_until_timeout = cluster.get_workflow_timeout_seconds()
-    wf_status = workflow.run(resume=restart, seconds_until_timeout=seconds_until_timeout)
+    run_kwargs: dict[str, Any] = {"resume": restart}
+    if seconds_until_timeout is not None:
+        run_kwargs["seconds_until_timeout"] = seconds_until_timeout
+    wf_status = workflow.run(**run_kwargs)
 
     # Spit out a performance report for the workers.
     try_run_vipin(output_paths)

--- a/tests/psimulate/cluster/test_interface.py
+++ b/tests/psimulate/cluster/test_interface.py
@@ -9,7 +9,6 @@ import pytest
 from vivarium_cluster_tools.psimulate.cluster import validate_cluster_environment
 from vivarium_cluster_tools.psimulate.cluster.interface import (
     _SLURM_TIMEOUT_BUFFER_SECONDS,
-    JOBMON_DEFAULT_TIMEOUT,
     NativeSpecification,
     _parse_slurm_time,
     get_workflow_timeout_seconds,
@@ -179,9 +178,9 @@ class TestGetRunnerNodeRemainingSeconds:
         monkeypatch.setenv("SLURM_JOB_ID", "12345")
 
     def test_no_slurm_job_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Raise when not inside a SLURM allocation."""
+        """Return None when not inside a SLURM allocation."""
         monkeypatch.delenv("SLURM_JOB_ID")
-        assert get_workflow_timeout_seconds() == JOBMON_DEFAULT_TIMEOUT
+        assert get_workflow_timeout_seconds() is None
 
     def test_returns_remaining_minus_buffer(self) -> None:
         """Return remaining seconds minus the safety buffer."""

--- a/tests/psimulate/cluster/test_interface.py
+++ b/tests/psimulate/cluster/test_interface.py
@@ -9,6 +9,7 @@ import pytest
 from vivarium_cluster_tools.psimulate.cluster import validate_cluster_environment
 from vivarium_cluster_tools.psimulate.cluster.interface import (
     _SLURM_TIMEOUT_BUFFER_SECONDS,
+    JOBMON_DEFAULT_TIMEOUT,
     NativeSpecification,
     _parse_slurm_time,
     get_workflow_timeout_seconds,
@@ -180,7 +181,7 @@ class TestGetRunnerNodeRemainingSeconds:
     def test_no_slurm_job_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Raise when not inside a SLURM allocation."""
         monkeypatch.delenv("SLURM_JOB_ID")
-        assert get_workflow_timeout_seconds() == 36000
+        assert get_workflow_timeout_seconds() == JOBMON_DEFAULT_TIMEOUT
 
     def test_returns_remaining_minus_buffer(self) -> None:
         """Return remaining seconds minus the safety buffer."""

--- a/tests/psimulate/cluster/test_interface.py
+++ b/tests/psimulate/cluster/test_interface.py
@@ -180,8 +180,7 @@ class TestGetRunnerNodeRemainingSeconds:
     def test_no_slurm_job_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Raise when not inside a SLURM allocation."""
         monkeypatch.delenv("SLURM_JOB_ID")
-        with pytest.raises(RuntimeError, match="SLURM_JOB_ID is not set"):
-            get_workflow_timeout_seconds()
+        assert get_workflow_timeout_seconds() == 36000
 
     def test_returns_remaining_minus_buffer(self) -> None:
         """Return remaining seconds minus the safety buffer."""

--- a/tests/psimulate/test_e2e.py
+++ b/tests/psimulate/test_e2e.py
@@ -44,7 +44,7 @@ _EXPECTED_TOTAL_JOBS = 4
 
 RESULTS_DIR = "/mnt/team/simulation_science/priv/engineering/tests/output/"
 
-pytestmark = [pytest.mark.cluster, pytest.mark.slow]
+pytestmark = [pytest.mark.cluster, pytest.mark.slow, pytest.mark.weekly]
 
 
 def _make_shared_tmp_dir() -> Path:

--- a/tests/psimulate/test_e2e.py
+++ b/tests/psimulate/test_e2e.py
@@ -44,7 +44,7 @@ _EXPECTED_TOTAL_JOBS = 4
 
 RESULTS_DIR = "/mnt/team/simulation_science/priv/engineering/tests/output/"
 
-pytestmark = [pytest.mark.cluster, pytest.mark.slow, pytest.mark.weekly]
+pytestmark = [pytest.mark.cluster, pytest.mark.slow]
 
 
 def _make_shared_tmp_dir() -> Path:


### PR DESCRIPTION
## Make VCT require slurm node resources weekly
<!-- Ideally, <=50 chars. 50 chars is here..: -->

### Description
<!-- For use in commit message, wrap at 72 chars. 72 chars is here: -->
- *Category*: <!-- one of bugfix, feature, refactor, POC, CI/infrastructure, documentation, 
                   revert, test, release, other/misc -->
bugfix
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7051

### Changes and notes
<!-- 
Change description – why, what, anything unexplained by the above.
Include guidance to reviewers if changes are complex.
--> 
add the "weekly" flag to VCT so that we build end to end tests appropriately.
also, replace raise for unset env var with a default value.
### Testing
<!--
Details on how code was verified, any unit tests local for the
repo, regression testing, etc. At a minimum, this should include an
integration test for a framework change. Consider: plots, images,
(small) csv file.
-->
ran with jenkins, with run weekly flag and without
