### PR TITLE
Albrja/mic 7063/v2 notebook step

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
+++ b/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
@@ -1097,6 +1097,7 @@ class NotebookStepConfig(BaseStepConfig):
             "papermill",
             shlex.quote(str(self.path)),
             shlex.quote(str(self.output_path)),
+            "-k python3",
         ]
         for key in sorted(self.parameters):
             value = self.parameters[key]

--- a/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
+++ b/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
@@ -324,6 +324,7 @@ class BaseStepConfig(ABC):
         to subclass-specific ``_build_from_dict`` for construction.
 
         Parameters
+        ----------
         data
             Dictionary from workflow YAML.
         output_directory

--- a/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
+++ b/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
@@ -974,6 +974,58 @@ class PythonStepConfig(BaseStepConfig):
 
 
 @dataclass
+class NotebookStepConfig(BaseStepConfig):
+    """Configuration for a notebook-based workflow step.
+
+    Currently routes to ``papermill`` under the hood, but exposes a
+    notebook-agnostic schema so the executor can be swapped later.
+    """
+
+    _SUPPORTED_ARGS: ClassVar[set[str]] = {"path", "parameters", "output_path", "cwd"}
+    _SCALAR_TYPES: ClassVar[tuple[type, ...]] = (str, int, float, bool)
+
+    name: str
+    """Unique name for this step within the workflow."""
+    resources: ResourceConfig
+    """Compute resources for this step."""
+    output_directory: Path
+    """Output directory for this step. Inherited from the workflow's output_directory."""
+    path: Path
+    """Path to the input notebook (.ipynb). Both relative and absolute paths are
+    accepted; resolved to absolute when serialized."""
+    output_path: Path
+    """Where to write the executed notebook (.ipynb). Both relative and absolute
+    paths are accepted."""
+    environment: str | None = None
+    """Optional environment name to use for this step."""
+    parameters: dict[str, Any] = field(default_factory=dict)
+    """Notebook parameters injected as cell-level variables. Scalar values only."""
+    cwd: Path | None = None
+    """Optional working directory for notebook execution. Both relative and absolute
+    paths are accepted."""
+
+    def _validate(self) -> None:
+        pass
+
+    def _build_command(self) -> str:
+        raise NotImplementedError
+
+    def to_dict(self) -> dict[str, Any]:
+        raise NotImplementedError
+
+    @classmethod
+    def _build_from_dict(
+        cls,
+        data: dict[str, Any],
+        output_directory: Path,
+        *,
+        project: str,
+        queue: str,
+    ) -> NotebookStepConfig:
+        raise NotImplementedError
+
+
+@dataclass
 class WorkflowConfig:
     """Parsed and validated workflow configuration."""
 
@@ -982,6 +1034,7 @@ class WorkflowConfig:
         "simulation": SimulationStepConfig,
         "pytest": PytestStepConfig,
         "python": PythonStepConfig,
+        "notebook": NotebookStepConfig,
     }
 
     name: str

--- a/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
+++ b/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
@@ -47,6 +47,57 @@ DEFAULT_BACKUP_FREQ_SECONDS = 30.0 * 60.0
 """Default backup frequency in seconds (30 minutes), matching ``psimulate run``."""
 
 
+_SCALAR_TYPES: tuple[type, ...] = (str, int, float, bool)
+"""Scalar value types accepted in step args (e.g. notebook ``parameters``,
+python ``keyword_args`` / ``positional_args``)."""
+
+_IDENTIFIER_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+"""Pattern for keys in scalar-dict step args (``keyword_args``, ``parameters``)."""
+
+
+def _validate_scalar_dict(
+    configuration: object,
+    *,
+    field_name: str,
+    step_name: str,
+    allow_none_values: bool = True,
+) -> None:
+    """Validate ``configuration`` is a dict of identifier-keyed scalar values.
+
+    Parameters
+    ----------
+    configuration
+        The untrusted value to validate (typically a sub-dict from a step's
+        YAML ``args``).
+    field_name
+        Name of the field being validated, used in error messages
+        (e.g. ``"keyword_args"`` or ``"parameters"``).
+    step_name
+        Name of the owning step, used in error messages.
+    allow_none_values
+        Whether ``None`` is an acceptable value (treated as a flag for
+        keyword args; treated as YAML ``null`` for notebook parameters).
+    """
+    if not isinstance(configuration, dict):
+        raise ValueError(
+            f"Step '{step_name}': '{field_name}' must be a dict, "
+            f"got {type(configuration).__name__}."
+        )
+    allowed = (*_SCALAR_TYPES, type(None)) if allow_none_values else _SCALAR_TYPES
+    for key, value in configuration.items():
+        if not isinstance(key, str) or not _IDENTIFIER_RE.match(key):
+            raise ValueError(
+                f"Step '{step_name}': {field_name} key {key!r} is not a valid "
+                "identifier. Keys must match [a-zA-Z0-9_-]+."
+            )
+        if not isinstance(value, allowed):
+            raise ValueError(
+                f"Step '{step_name}': {field_name}['{key}'] must be a scalar type "
+                f"({', '.join(t.__name__ for t in allowed)}), "
+                f"got {type(value).__name__}."
+            )
+
+
 @dataclass
 class ResourceConfig:
     """Compute resource specification for a workflow step."""
@@ -273,7 +324,6 @@ class BaseStepConfig(ABC):
         to subclass-specific ``_build_from_dict`` for construction.
 
         Parameters
-        ----------
         data
             Dictionary from workflow YAML.
         output_directory
@@ -838,7 +888,6 @@ class PythonStepConfig(BaseStepConfig):
     """
 
     _SUPPORTED_ARGS: ClassVar[set[str]] = {"path", "positional_args", "keyword_args"}
-    _SCALAR_TYPES: ClassVar[tuple[type, ...]] = (str, int, float, bool)
 
     name: str
     """Unique name for this step within the workflow."""
@@ -868,7 +917,11 @@ class PythonStepConfig(BaseStepConfig):
         if "positional_args" in self.args:
             self._validate_positional_args(self.args["positional_args"])
         if "keyword_args" in self.args:
-            self._validate_keyword_args(self.args["keyword_args"])
+            _validate_scalar_dict(
+                self.args["keyword_args"],
+                field_name="keyword_args",
+                step_name=self.name,
+            )
 
     @property
     def required_paths(self) -> list[Path]:
@@ -888,7 +941,7 @@ class PythonStepConfig(BaseStepConfig):
             Whether ``None`` is accepted. Positional args do not allow ``None``
             (it has no CLI representation), while keyword args do (treated as a flag).
         """
-        allowed = (*self._SCALAR_TYPES, type(None)) if allow_none else self._SCALAR_TYPES
+        allowed = (*_SCALAR_TYPES, type(None)) if allow_none else _SCALAR_TYPES
         if not isinstance(value, allowed):
             raise ValueError(
                 f"Step '{self.name}': {label} must be a scalar type "
@@ -905,21 +958,6 @@ class PythonStepConfig(BaseStepConfig):
             )
         for arg_index, item in enumerate(positional_args):
             self._validate_scalar(item, f"positional_args[{arg_index}]", allow_none=False)
-
-    def _validate_keyword_args(self, keyword_args: Any) -> None:
-        """Validate that keyword_args is a dict with valid keys and scalar values."""
-        if not isinstance(keyword_args, dict):
-            raise ValueError(
-                f"Step '{self.name}': 'keyword_args' must be a dict, "
-                f"got {type(keyword_args).__name__}."
-            )
-        for key, value in keyword_args.items():
-            if not re.match(r"^[a-zA-Z0-9_-]+$", key):
-                raise ValueError(
-                    f"Step '{self.name}': keyword_args key {key!r} is not a valid "
-                    "identifier. Keys must match [a-zA-Z0-9_-]+."
-                )
-            self._validate_scalar(value, f"keyword_args['{key}']")
 
     def _build_command(self) -> str:
         """Build the python command string from the script path and args.
@@ -979,10 +1017,36 @@ class NotebookStepConfig(BaseStepConfig):
 
     Currently routes to ``papermill`` under the hood, but exposes a
     notebook-agnostic schema so the executor can be swapped later.
+
+    Examples
+    --------
+    YAML configuration::
+
+        steps:
+          - name: post_notebook_neonatal
+            type: notebook
+            resources:
+              memory_gb: 20
+              runtime: "02:00:00"
+            args:
+              path: tests/model_notebooks/results/neonatal.ipynb
+              output_path: /mnt/results/run_29/executed/neonatal.ipynb
+              parameters:
+                model_dir: /mnt/results/run_29
+                year: 2020
+                verbose: true
+
+    Notes
+    -----
+    Parameter values map to papermill flags as follows:
+
+    - ``str`` / ``int`` / ``float`` -> ``-p key value``
+    - ``bool`` / ``None`` -> ``-y key {true,false,null}`` (YAML-typed)
+
+    Parameters are emitted sorted by key for deterministic command output.
     """
 
     _SUPPORTED_ARGS: ClassVar[set[str]] = {"path", "parameters", "output_path", "cwd"}
-    _SCALAR_TYPES: ClassVar[tuple[type, ...]] = (str, int, float, bool)
 
     name: str
     """Unique name for this step within the workflow."""
@@ -1002,16 +1066,69 @@ class NotebookStepConfig(BaseStepConfig):
     """Notebook parameters injected as cell-level variables. Scalar values only."""
     cwd: Path | None = None
     """Optional working directory for notebook execution. Both relative and absolute
-    paths are accepted."""
+    paths are accepted. If not provided, defaults to the parent directory of ``path``."""
 
     def _validate(self) -> None:
-        pass
+        if not str(self.path).endswith(".ipynb"):
+            raise ValueError(
+                f"Step '{self.name}': 'path' must end with .ipynb, " f"got {self.path!r}."
+            )
+        if not str(self.output_path).endswith(".ipynb"):
+            raise ValueError(
+                f"Step '{self.name}': 'output_path' must end with .ipynb, "
+                f"got {self.output_path!r}."
+            )
+        _validate_scalar_dict(
+            self.parameters,
+            field_name="parameters",
+            step_name=self.name,
+        )
+
+    @property
+    def required_paths(self) -> list[Path]:
+        return [self.path]
 
     def _build_command(self) -> str:
-        raise NotImplementedError
+        cwd = self.cwd if self.cwd is not None else self.path.parent
+        parts = [
+            f"mkdir -p {shlex.quote(str(self.output_path.parent))}",
+            "&&",
+            "papermill",
+            shlex.quote(str(self.path)),
+            shlex.quote(str(self.output_path)),
+        ]
+        for key in sorted(self.parameters):
+            value = self.parameters[key]
+            if isinstance(value, bool) or value is None:
+                yaml_value = (
+                    "true" if value is True else "false" if value is False else "null"
+                )
+                parts.append(f"-y {key} {yaml_value}")
+            else:
+                parts.append(f"-p {key} {shlex.quote(str(value))}")
+        parts.append(f"--cwd {shlex.quote(str(cwd))}")
+        return " ".join(parts)
 
     def to_dict(self) -> dict[str, Any]:
-        raise NotImplementedError
+        result: dict[str, Any] = {
+            "name": self.name,
+            "type": "notebook",
+            "resources": self.resources.to_dict(),
+        }
+        if self.environment is not None:
+            result["environment"] = self.environment
+
+        args: dict[str, Any] = {
+            "path": str(self.path),
+            "output_path": str(self.output_path),
+        }
+        if self.parameters:
+            args["parameters"] = copy.deepcopy(self.parameters)
+        if self.cwd is not None:
+            args["cwd"] = str(self.cwd)
+
+        result["args"] = args
+        return result
 
     @classmethod
     def _build_from_dict(
@@ -1022,7 +1139,25 @@ class NotebookStepConfig(BaseStepConfig):
         project: str,
         queue: str,
     ) -> NotebookStepConfig:
-        raise NotImplementedError
+        args = copy.deepcopy(data["args"])
+
+        kwargs: dict[str, Any] = {
+            "name": data["name"],
+            "resources": ResourceConfig.from_dict(
+                data["resources"], workflow_project=project, workflow_queue=queue
+            ),
+            "output_directory": output_directory,
+            "path": Path(args["path"]).resolve(),
+            "output_path": Path(args["output_path"]).resolve(),
+        }
+        if "environment" in data:
+            kwargs["environment"] = data["environment"]
+        if "parameters" in args:
+            kwargs["parameters"] = args["parameters"]
+        if "cwd" in args:
+            kwargs["cwd"] = Path(args["cwd"]).resolve()
+
+        return cls(**kwargs)
 
 
 @dataclass

--- a/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
+++ b/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
@@ -116,7 +116,7 @@ def _validate_scalar_dict(
         if not isinstance(key, str) or not _IDENTIFIER_RE.match(key):
             raise ValueError(
                 f"Step '{step_name}': {field_name} key {key!r} is not a valid "
-                "identifier. Keys must match [a-zA-Z0-9_-]+."
+                "identifier. Keys must be alphanumeric, have dashes, or underscores."
             )
         _check_scalar(
             value,
@@ -1108,7 +1108,7 @@ class NotebookStepConfig(BaseStepConfig):
             if not self._PYTHON_IDENTIFIER_RE.match(key):
                 raise ValueError(
                     f"Step '{self.name}': parameter key {key!r} is not a valid "
-                    "Python identifier. Papermill requires parameter names that "
+                    "Python identifier. Notebooks require parameter names that "
                     "are valid Python identifiers (letters, digits, underscores; "
                     "cannot start with a digit)."
                 )

--- a/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
+++ b/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
@@ -55,6 +55,35 @@ _IDENTIFIER_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
 """Pattern for keys in scalar-dict step args (``keyword_args``, ``parameters``)."""
 
 
+def _check_scalar(
+    value: object,
+    *,
+    label: str,
+    step_name: str,
+    allow_none: bool = True,
+) -> None:
+    """Validate that *value* is a scalar type.
+
+    Parameters
+    ----------
+    value
+        The value to check.
+    label
+        Human-readable label for error messages (e.g. ``"positional_args[0]"``).
+    step_name
+        Name of the owning step, used in error messages.
+    allow_none
+        Whether ``None`` is an acceptable value.
+    """
+    allowed = (*_SCALAR_TYPES, type(None)) if allow_none else _SCALAR_TYPES
+    if not isinstance(value, allowed):
+        raise ValueError(
+            f"Step '{step_name}': {label} must be a scalar type "
+            f"({', '.join(t.__name__ for t in allowed)}), "
+            f"got {type(value).__name__}."
+        )
+
+
 def _validate_scalar_dict(
     configuration: object,
     *,
@@ -83,19 +112,18 @@ def _validate_scalar_dict(
             f"Step '{step_name}': '{field_name}' must be a dict, "
             f"got {type(configuration).__name__}."
         )
-    allowed = (*_SCALAR_TYPES, type(None)) if allow_none_values else _SCALAR_TYPES
     for key, value in configuration.items():
         if not isinstance(key, str) or not _IDENTIFIER_RE.match(key):
             raise ValueError(
                 f"Step '{step_name}': {field_name} key {key!r} is not a valid "
                 "identifier. Keys must match [a-zA-Z0-9_-]+."
             )
-        if not isinstance(value, allowed):
-            raise ValueError(
-                f"Step '{step_name}': {field_name}['{key}'] must be a scalar type "
-                f"({', '.join(t.__name__ for t in allowed)}), "
-                f"got {type(value).__name__}."
-            )
+        _check_scalar(
+            value,
+            label=f"{field_name}['{key}']",
+            step_name=step_name,
+            allow_none=allow_none_values,
+        )
 
 
 @dataclass
@@ -929,27 +957,6 @@ class PythonStepConfig(BaseStepConfig):
         """Return paths that must exist for python steps."""
         return [Path(self.args["path"])]
 
-    def _validate_scalar(self, value: Any, label: str, *, allow_none: bool = True) -> None:
-        """Validate that *value* is a scalar type suitable for CLI usage.
-
-        Parameters
-        ----------
-        value
-            The value to check.
-        label
-            Human-readable label for error messages (e.g. ``"positional_args[0]"``).
-        allow_none
-            Whether ``None`` is accepted. Positional args do not allow ``None``
-            (it has no CLI representation), while keyword args do (treated as a flag).
-        """
-        allowed = (*_SCALAR_TYPES, type(None)) if allow_none else _SCALAR_TYPES
-        if not isinstance(value, allowed):
-            raise ValueError(
-                f"Step '{self.name}': {label} must be a scalar type "
-                f"({', '.join(t.__name__ for t in allowed)}), "
-                f"got {type(value).__name__}."
-            )
-
     def _validate_positional_args(self, positional_args: Any) -> None:
         """Validate that positional_args is a list of scalar values."""
         if not isinstance(positional_args, list):
@@ -958,7 +965,12 @@ class PythonStepConfig(BaseStepConfig):
                 f"got {type(positional_args).__name__}."
             )
         for arg_index, item in enumerate(positional_args):
-            self._validate_scalar(item, f"positional_args[{arg_index}]", allow_none=False)
+            _check_scalar(
+                item,
+                label=f"positional_args[{arg_index}]",
+                step_name=self.name,
+                allow_none=False,
+            )
 
     def _build_command(self) -> str:
         """Build the python command string from the script path and args.
@@ -1069,6 +1081,14 @@ class NotebookStepConfig(BaseStepConfig):
     """Optional working directory for notebook execution. Both relative and absolute
     paths are accepted. If not provided, defaults to the parent directory of ``path``."""
 
+    _DEFAULT_KERNEL: ClassVar[str] = "python3"
+    """Jupyter kernel used for notebook execution. Not user-configurable;
+    extracted here for discoverability."""
+
+    _PYTHON_IDENTIFIER_RE: ClassVar[re.Pattern[str]] = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+    """Parameter keys must be valid Python identifiers because papermill
+    injects them as variable assignments in a notebook cell."""
+
     def _validate(self) -> None:
         if not str(self.path).endswith(".ipynb"):
             raise ValueError(
@@ -1084,6 +1104,14 @@ class NotebookStepConfig(BaseStepConfig):
             field_name="parameters",
             step_name=self.name,
         )
+        for key in self.parameters:
+            if not self._PYTHON_IDENTIFIER_RE.match(key):
+                raise ValueError(
+                    f"Step '{self.name}': parameter key {key!r} is not a valid "
+                    "Python identifier. Papermill requires parameter names that "
+                    "are valid Python identifiers (letters, digits, underscores; "
+                    "cannot start with a digit)."
+                )
 
     @property
     def required_paths(self) -> list[Path]:
@@ -1097,7 +1125,7 @@ class NotebookStepConfig(BaseStepConfig):
             "papermill",
             shlex.quote(str(self.path)),
             shlex.quote(str(self.output_path)),
-            "-k python3",
+            f"-k {self._DEFAULT_KERNEL}",
         ]
         for key in sorted(self.parameters):
             value = self.parameters[key]
@@ -1105,7 +1133,7 @@ class NotebookStepConfig(BaseStepConfig):
                 yaml_value = (
                     "true" if value is True else "false" if value is False else "null"
                 )
-                parts.append(f"-y {key} {yaml_value}")
+                parts.append(f"-y {shlex.quote(f'{key}: {yaml_value}')}")
             else:
                 parts.append(f"-p {key} {shlex.quote(str(value))}")
         parts.append(f"--cwd {shlex.quote(str(cwd))}")
@@ -1142,6 +1170,12 @@ class NotebookStepConfig(BaseStepConfig):
         queue: str,
     ) -> NotebookStepConfig:
         args = copy.deepcopy(data["args"])
+        step_name = data.get("name", "<unnamed>")
+
+        if "output_path" not in args:
+            raise ValueError(
+                f"Step '{step_name}': notebook type requires 'output_path' in args."
+            )
 
         kwargs: dict[str, Any] = {
             "name": data["name"],

--- a/tests/psimulate/workflow_config/conftest.py
+++ b/tests/psimulate/workflow_config/conftest.py
@@ -41,6 +41,14 @@ def valid_python_script(tmp_path_factory: pytest.TempPathFactory) -> str:
     return str(script)
 
 
+@pytest.fixture(scope="session")
+def valid_notebook_path(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """A valid notebook path for notebook steps."""
+    notebook = tmp_path_factory.mktemp("notebooks") / "analysis.ipynb"
+    notebook.write_text("")
+    return notebook
+
+
 @pytest.fixture()
 def valid_workflow_dict() -> dict[str, Any]:
     """A valid minimal workflow config dict."""

--- a/tests/psimulate/workflow_config/test_config.py
+++ b/tests/psimulate/workflow_config/test_config.py
@@ -1171,40 +1171,40 @@ class TestNotebookStepConfig:
         [
             (
                 {},
-                "mkdir -p {out_parent} && papermill {input} {output} --cwd {input_parent}",
+                "mkdir -p {out_parent} && papermill {input} {output} -k python3 --cwd {input_parent}",
             ),
             (
                 {"parameters": {"name": "alice"}},
-                "mkdir -p {out_parent} && papermill {input} {output}"
+                "mkdir -p {out_parent} && papermill {input} {output} -k python3"
                 " -p name alice --cwd {input_parent}",
             ),
             (
                 {"parameters": {"verbose": True}},
-                "mkdir -p {out_parent} && papermill {input} {output}"
+                "mkdir -p {out_parent} && papermill {input} {output} -k python3"
                 " -y verbose true --cwd {input_parent}",
             ),
             (
                 {"parameters": {"flag": False}},
-                "mkdir -p {out_parent} && papermill {input} {output}"
+                "mkdir -p {out_parent} && papermill {input} {output} -k python3"
                 " -y flag false --cwd {input_parent}",
             ),
             (
                 {"parameters": {"missing": None}},
-                "mkdir -p {out_parent} && papermill {input} {output}"
+                "mkdir -p {out_parent} && papermill {input} {output} -k python3"
                 " -y missing null --cwd {input_parent}",
             ),
             (
                 {"parameters": {"name": "alice", "verbose": True, "year": 2020}},
-                "mkdir -p {out_parent} && papermill {input} {output}"
+                "mkdir -p {out_parent} && papermill {input} {output} -k python3"
                 " -p name alice -y verbose true -p year 2020 --cwd {input_parent}",
             ),
             (
                 {"cwd": Path("/tmp/notebooks")},
-                "mkdir -p {out_parent} && papermill {input} {output} --cwd /tmp/notebooks",
+                "mkdir -p {out_parent} && papermill {input} {output} -k python3 --cwd /tmp/notebooks",
             ),
             (
                 {"parameters": {"msg": "hello world"}},
-                "mkdir -p {out_parent} && papermill {input} {output}"
+                "mkdir -p {out_parent} && papermill {input} {output} -k python3"
                 " -p msg 'hello world' --cwd {input_parent}",
             ),
         ],

--- a/tests/psimulate/workflow_config/test_config.py
+++ b/tests/psimulate/workflow_config/test_config.py
@@ -1123,7 +1123,6 @@ class TestNotebookStepConfig:
         with pytest.raises(TypeError, match=omitted_field):
             NotebookStepConfig(**kwargs)
 
-    @pytest.mark.xfail(strict=True, reason="phase 1 stub: implementation pending")
     @pytest.mark.parametrize(
         "overrides, match",
         [
@@ -1163,12 +1162,10 @@ class TestNotebookStepConfig:
                 queue="all.q",
             )
 
-    @pytest.mark.xfail(strict=True, reason="phase 1 stub: implementation pending")
     def test_required_paths_only_contains_input(self, valid_notebook_path: Path) -> None:
         config = NotebookStepConfig(**self._base_kwargs(valid_notebook_path))
         assert config.required_paths == [valid_notebook_path]
 
-    @pytest.mark.xfail(strict=True, reason="phase 1 stub: implementation pending")
     @pytest.mark.parametrize(
         "field_overrides, expected_command_template",
         [
@@ -1239,7 +1236,6 @@ class TestNotebookStepConfig:
         )
         assert config._build_command() == expected
 
-    @pytest.mark.xfail(strict=True, reason="phase 1 stub: implementation pending")
     def test_to_dict_serialization(self, valid_notebook_path: Path) -> None:
         config = NotebookStepConfig(
             name="run_notebook",
@@ -1265,7 +1261,6 @@ class TestNotebookStepConfig:
         )
         assert result["args"]["cwd"] == str(Path("/tmp/notebooks"))
 
-    @pytest.mark.xfail(strict=True, reason="phase 1 stub: implementation pending")
     def test_to_dict_round_trip(self, valid_notebook_path: Path) -> None:
         config = NotebookStepConfig(
             name="run_notebook",
@@ -1287,7 +1282,6 @@ class TestNotebookStepConfig:
         assert restored.parameters == config.parameters
         assert restored.output_path == config.output_path
 
-    @pytest.mark.xfail(strict=True, reason="phase 1 stub: implementation pending")
     def test_from_dict_resolves_paths(
         self, tmp_path: Path, valid_notebook_path: Path
     ) -> None:
@@ -1308,7 +1302,6 @@ class TestNotebookStepConfig:
         assert config.output_path is not None and config.output_path.is_absolute()
         assert config.cwd is not None and config.cwd.is_absolute()
 
-    @pytest.mark.xfail(strict=True, reason="phase 1 stub: implementation pending")
     def test_routes_to_notebook_step_from_yaml(
         self, tmp_path: Path, valid_notebook_path: Path
     ) -> None:

--- a/tests/psimulate/workflow_config/test_config.py
+++ b/tests/psimulate/workflow_config/test_config.py
@@ -1131,6 +1131,8 @@ class TestNotebookStepConfig:
             ({"parameters": [1, 2, 3]}, "dict"),
             ({"parameters": {"x": {"nested": 1}}}, "scalar"),
             ({"parameters": {"bad key!": 1}}, "identifier"),
+            ({"parameters": {"hyphen-key": 1}}, "Python identifier"),
+            ({"parameters": {"2startsdigit": 1}}, "Python identifier"),
         ],
         ids=[
             "non_ipynb_path",
@@ -1138,6 +1140,8 @@ class TestNotebookStepConfig:
             "parameters_not_dict",
             "non_scalar_parameter_value",
             "invalid_parameter_key",
+            "hyphenated_parameter_key",
+            "digit_start_parameter_key",
         ],
     )
     def test_rejects_invalid_configurations(
@@ -1149,6 +1153,18 @@ class TestNotebookStepConfig:
         kwargs = {**self._base_kwargs(valid_notebook_path), **overrides}
         with pytest.raises(ValueError, match=match):
             NotebookStepConfig(**kwargs)
+
+    def test_from_dict_rejects_missing_output_path(self, valid_notebook_path: Path) -> None:
+        step_dict = make_notebook_step_dict(
+            args={"path": str(valid_notebook_path)},
+        )
+        with pytest.raises(ValueError, match="output_path"):
+            NotebookStepConfig.from_dict(
+                step_dict,
+                output_directory=Path("/tmp/results"),
+                project="proj_simscience",
+                queue="all.q",
+            )
 
     def test_from_dict_rejects_unsupported_args(self, valid_notebook_path: Path) -> None:
         step_dict = make_notebook_step_dict(
@@ -1181,22 +1197,22 @@ class TestNotebookStepConfig:
             (
                 {"parameters": {"verbose": True}},
                 "mkdir -p {out_parent} && papermill {input} {output} -k python3"
-                " -y verbose true --cwd {input_parent}",
+                " -y 'verbose: true' --cwd {input_parent}",
             ),
             (
                 {"parameters": {"flag": False}},
                 "mkdir -p {out_parent} && papermill {input} {output} -k python3"
-                " -y flag false --cwd {input_parent}",
+                " -y 'flag: false' --cwd {input_parent}",
             ),
             (
                 {"parameters": {"missing": None}},
                 "mkdir -p {out_parent} && papermill {input} {output} -k python3"
-                " -y missing null --cwd {input_parent}",
+                " -y 'missing: null' --cwd {input_parent}",
             ),
             (
                 {"parameters": {"name": "alice", "verbose": True, "year": 2020}},
                 "mkdir -p {out_parent} && papermill {input} {output} -k python3"
-                " -p name alice -y verbose true -p year 2020 --cwd {input_parent}",
+                " -p name alice -y 'verbose: true' -p year 2020 --cwd {input_parent}",
             ),
             (
                 {"cwd": Path("/tmp/notebooks")},

--- a/tests/psimulate/workflow_config/test_config.py
+++ b/tests/psimulate/workflow_config/test_config.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from tests.psimulate.workflow_config.utilities import (
+    make_notebook_step_dict,
     make_pytest_step_dict,
     make_python_step_dict,
     make_step_dict,
@@ -17,6 +18,7 @@ from tests.psimulate.workflow_config.utilities import (
 )
 from vivarium_cluster_tools.psimulate.workflow_config.config import (
     CommandStepConfig,
+    NotebookStepConfig,
     PytestStepConfig,
     PythonStepConfig,
     ResourceConfig,
@@ -265,8 +267,15 @@ class TestBaseStepConfig:
                 },
                 {"path", "positional_args", "keyword_args"},
             ),
+            (
+                NotebookStepConfig,
+                {
+                    "name": "notebook",
+                },
+                {"path", "parameters", "output_path", "cwd"},
+            ),
         ],
-        ids=["command", "pytest", "python"],
+        ids=["command", "pytest", "python", "notebook"],
     )
     def test_supported_arguments(
         self,
@@ -275,6 +284,7 @@ class TestBaseStepConfig:
         expected: set[str] | None,
         valid_pytest_path: str,
         valid_python_script: str,
+        valid_notebook_path: Path,
     ) -> None:
         common = {
             "resources": ResourceConfig(
@@ -286,6 +296,9 @@ class TestBaseStepConfig:
             kwargs["path"] = valid_pytest_path
         elif cls == PythonStepConfig:
             kwargs["args"] = {"path": valid_python_script}
+        elif cls == NotebookStepConfig:
+            kwargs["path"] = valid_notebook_path
+            kwargs["output_path"] = Path("/tmp/results/run_notebook.ipynb")
         config = cls(**{**common, **kwargs})
         assert config.supported_arguments == expected
 
@@ -1084,3 +1097,227 @@ class TestPythonStepConfig:
         assert len(config.steps) == 1
         assert isinstance(config.steps[0], PythonStepConfig)
         assert config.steps[0].name == "run_script"
+
+
+class TestNotebookStepConfig:
+    """Tests for NotebookStepConfig - the notebook step type."""
+
+    @staticmethod
+    def _base_kwargs(valid_notebook_path: Path) -> dict[str, Any]:
+        return {
+            "name": "run_notebook",
+            "resources": ResourceConfig(
+                memory_gb=4, project="proj_simscience", queue="all.q"
+            ),
+            "output_directory": Path("/tmp/results"),
+            "path": valid_notebook_path,
+            "output_path": Path("/tmp/results/run_notebook.ipynb"),
+        }
+
+    @pytest.mark.parametrize("omitted_field", ["path", "output_path"])
+    def test_requires_required_fields(
+        self, valid_notebook_path: Path, omitted_field: str
+    ) -> None:
+        kwargs = self._base_kwargs(valid_notebook_path)
+        del kwargs[omitted_field]
+        with pytest.raises(TypeError, match=omitted_field):
+            NotebookStepConfig(**kwargs)
+
+    @pytest.mark.xfail(strict=True, reason="phase 1 stub: implementation pending")
+    @pytest.mark.parametrize(
+        "overrides, match",
+        [
+            ({"path": Path("/tmp/foo.py")}, r"\.ipynb"),
+            ({"output_path": Path("/tmp/out.txt")}, r"\.ipynb"),
+            ({"parameters": [1, 2, 3]}, "dict"),
+            ({"parameters": {"x": {"nested": 1}}}, "scalar"),
+            ({"parameters": {"bad key!": 1}}, "identifier"),
+        ],
+        ids=[
+            "non_ipynb_path",
+            "non_ipynb_output_path",
+            "parameters_not_dict",
+            "non_scalar_parameter_value",
+            "invalid_parameter_key",
+        ],
+    )
+    def test_rejects_invalid_configurations(
+        self,
+        valid_notebook_path: Path,
+        overrides: dict[str, Any],
+        match: str,
+    ) -> None:
+        kwargs = {**self._base_kwargs(valid_notebook_path), **overrides}
+        with pytest.raises(ValueError, match=match):
+            NotebookStepConfig(**kwargs)
+
+    def test_from_dict_rejects_unsupported_args(self, valid_notebook_path: Path) -> None:
+        step_dict = make_notebook_step_dict(
+            args={"path": str(valid_notebook_path), "bogus": "nope"},
+        )
+        with pytest.raises(ValueError, match="unsupported args"):
+            NotebookStepConfig.from_dict(
+                step_dict,
+                output_directory=Path("/tmp/results"),
+                project="proj_simscience",
+                queue="all.q",
+            )
+
+    @pytest.mark.xfail(strict=True, reason="phase 1 stub: implementation pending")
+    def test_required_paths_only_contains_input(self, valid_notebook_path: Path) -> None:
+        config = NotebookStepConfig(**self._base_kwargs(valid_notebook_path))
+        assert config.required_paths == [valid_notebook_path]
+
+    @pytest.mark.xfail(strict=True, reason="phase 1 stub: implementation pending")
+    @pytest.mark.parametrize(
+        "field_overrides, expected_command_template",
+        [
+            (
+                {},
+                "mkdir -p {out_parent} && papermill {input} {output}",
+            ),
+            (
+                {"parameters": {"name": "alice"}},
+                "mkdir -p {out_parent} && papermill {input} {output} -p name alice",
+            ),
+            (
+                {"parameters": {"verbose": True}},
+                "mkdir -p {out_parent} && papermill {input} {output} -y verbose true",
+            ),
+            (
+                {"parameters": {"flag": False}},
+                "mkdir -p {out_parent} && papermill {input} {output} -y flag false",
+            ),
+            (
+                {"parameters": {"missing": None}},
+                "mkdir -p {out_parent} && papermill {input} {output} -y missing null",
+            ),
+            (
+                {"parameters": {"name": "alice", "verbose": True, "year": 2020}},
+                "mkdir -p {out_parent} && papermill {input} {output}"
+                " -p name alice -y verbose true -p year 2020",
+            ),
+            (
+                {"cwd": Path("/tmp/notebooks")},
+                "mkdir -p {out_parent} && papermill {input} {output}" " --cwd /tmp/notebooks",
+            ),
+            (
+                {"parameters": {"msg": "hello world"}},
+                "mkdir -p {out_parent} && papermill {input} {output}" " -p msg 'hello world'",
+            ),
+        ],
+        ids=[
+            "no_parameters",
+            "string_parameter",
+            "bool_true_via_y",
+            "bool_false_via_y",
+            "none_via_y",
+            "mixed_sorted_by_key",
+            "with_cwd",
+            "value_with_spaces_quoted",
+        ],
+    )
+    def test_build_command(
+        self,
+        valid_notebook_path: Path,
+        field_overrides: dict[str, Any],
+        expected_command_template: str,
+    ) -> None:
+        kwargs = {**self._base_kwargs(valid_notebook_path), **field_overrides}
+        config = NotebookStepConfig(**kwargs)
+        output_path = kwargs["output_path"]
+        expected = expected_command_template.format(
+            out_parent=output_path.parent,
+            input=valid_notebook_path,
+            output=output_path,
+        )
+        assert config._build_command() == expected
+
+    @pytest.mark.xfail(strict=True, reason="phase 1 stub: implementation pending")
+    def test_to_dict_serialization(self, valid_notebook_path: Path) -> None:
+        config = NotebookStepConfig(
+            name="run_notebook",
+            resources=ResourceConfig(
+                memory_gb=8,
+                runtime="02:00:00",
+                project="proj_simscience",
+                queue="all.q",
+            ),
+            output_directory=Path("/tmp/results"),
+            path=valid_notebook_path,
+            output_path=Path("/tmp/results/executed/run_notebook.ipynb"),
+            parameters={"year": 2020, "verbose": True},
+            cwd=Path("/tmp/notebooks"),
+        )
+        result = config.to_dict()
+        assert result["name"] == "run_notebook"
+        assert result["type"] == "notebook"
+        assert result["args"]["path"] == str(valid_notebook_path)
+        assert result["args"]["parameters"] == {"year": 2020, "verbose": True}
+        assert result["args"]["output_path"] == str(
+            Path("/tmp/results/executed/run_notebook.ipynb")
+        )
+        assert result["args"]["cwd"] == str(Path("/tmp/notebooks"))
+
+    @pytest.mark.xfail(strict=True, reason="phase 1 stub: implementation pending")
+    def test_to_dict_round_trip(self, valid_notebook_path: Path) -> None:
+        config = NotebookStepConfig(
+            name="run_notebook",
+            resources=ResourceConfig(memory_gb=4, project="proj_simscience", queue="all.q"),
+            output_directory=Path("/tmp/results"),
+            path=valid_notebook_path,
+            output_path=Path("/tmp/results/run_notebook.ipynb"),
+            parameters={"year": 2020},
+        )
+        serialized = config.to_dict()
+        restored = NotebookStepConfig.from_dict(
+            serialized,
+            output_directory=Path("/tmp/results"),
+            project="proj_simscience",
+            queue="all.q",
+        )
+        assert restored.name == config.name
+        assert restored.path == config.path
+        assert restored.parameters == config.parameters
+        assert restored.output_path == config.output_path
+
+    @pytest.mark.xfail(strict=True, reason="phase 1 stub: implementation pending")
+    def test_from_dict_resolves_paths(
+        self, tmp_path: Path, valid_notebook_path: Path
+    ) -> None:
+        step_dict = make_notebook_step_dict(
+            args={
+                "path": str(valid_notebook_path),
+                "output_path": "out.ipynb",
+                "cwd": ".",
+            },
+        )
+        config = NotebookStepConfig.from_dict(
+            step_dict,
+            output_directory=Path("/tmp/results"),
+            project="proj_simscience",
+            queue="all.q",
+        )
+        assert config.path is not None and config.path.is_absolute()
+        assert config.output_path is not None and config.output_path.is_absolute()
+        assert config.cwd is not None and config.cwd.is_absolute()
+
+    @pytest.mark.xfail(strict=True, reason="phase 1 stub: implementation pending")
+    def test_routes_to_notebook_step_from_yaml(
+        self, tmp_path: Path, valid_notebook_path: Path
+    ) -> None:
+        steps = [
+            make_notebook_step_dict(
+                args={
+                    "path": str(valid_notebook_path),
+                    "output_path": "out.ipynb",
+                },
+            )
+        ]
+        workflow_dict = make_workflow_dict(steps=steps)
+        yaml_path = write_workflow_yaml(tmp_path, workflow_dict)
+
+        config = WorkflowConfig.from_yaml_with_cli_overrides(yaml_path)
+        assert len(config.steps) == 1
+        assert isinstance(config.steps[0], NotebookStepConfig)
+        assert config.steps[0].name == "run_notebook"

--- a/tests/psimulate/workflow_config/test_config.py
+++ b/tests/psimulate/workflow_config/test_config.py
@@ -1174,40 +1174,45 @@ class TestNotebookStepConfig:
         [
             (
                 {},
-                "mkdir -p {out_parent} && papermill {input} {output}",
+                "mkdir -p {out_parent} && papermill {input} {output} --cwd {input_parent}",
             ),
             (
                 {"parameters": {"name": "alice"}},
-                "mkdir -p {out_parent} && papermill {input} {output} -p name alice",
+                "mkdir -p {out_parent} && papermill {input} {output}"
+                " -p name alice --cwd {input_parent}",
             ),
             (
                 {"parameters": {"verbose": True}},
-                "mkdir -p {out_parent} && papermill {input} {output} -y verbose true",
+                "mkdir -p {out_parent} && papermill {input} {output}"
+                " -y verbose true --cwd {input_parent}",
             ),
             (
                 {"parameters": {"flag": False}},
-                "mkdir -p {out_parent} && papermill {input} {output} -y flag false",
+                "mkdir -p {out_parent} && papermill {input} {output}"
+                " -y flag false --cwd {input_parent}",
             ),
             (
                 {"parameters": {"missing": None}},
-                "mkdir -p {out_parent} && papermill {input} {output} -y missing null",
+                "mkdir -p {out_parent} && papermill {input} {output}"
+                " -y missing null --cwd {input_parent}",
             ),
             (
                 {"parameters": {"name": "alice", "verbose": True, "year": 2020}},
                 "mkdir -p {out_parent} && papermill {input} {output}"
-                " -p name alice -y verbose true -p year 2020",
+                " -p name alice -y verbose true -p year 2020 --cwd {input_parent}",
             ),
             (
                 {"cwd": Path("/tmp/notebooks")},
-                "mkdir -p {out_parent} && papermill {input} {output}" " --cwd /tmp/notebooks",
+                "mkdir -p {out_parent} && papermill {input} {output} --cwd /tmp/notebooks",
             ),
             (
                 {"parameters": {"msg": "hello world"}},
-                "mkdir -p {out_parent} && papermill {input} {output}" " -p msg 'hello world'",
+                "mkdir -p {out_parent} && papermill {input} {output}"
+                " -p msg 'hello world' --cwd {input_parent}",
             ),
         ],
         ids=[
-            "no_parameters",
+            "no_parameters_defaults_cwd_to_path_parent",
             "string_parameter",
             "bool_true_via_y",
             "bool_false_via_y",
@@ -1229,6 +1234,7 @@ class TestNotebookStepConfig:
         expected = expected_command_template.format(
             out_parent=output_path.parent,
             input=valid_notebook_path,
+            input_parent=valid_notebook_path.parent,
             output=output_path,
         )
         assert config._build_command() == expected

--- a/tests/psimulate/workflow_config/utilities.py
+++ b/tests/psimulate/workflow_config/utilities.py
@@ -130,3 +130,24 @@ def make_python_step_dict(**overrides: Any) -> dict[str, Any]:
     }
     defaults.update(overrides)
     return defaults
+
+
+def make_notebook_step_dict(**overrides: Any) -> dict[str, Any]:
+    """Create a minimal valid notebook step dict with sensible defaults.
+
+    Returns a dict suitable for inclusion in a workflow's steps list.
+    Override any field or provide additional args.
+    """
+    defaults: dict[str, Any] = {
+        "name": "run_notebook",
+        "type": "notebook",
+        "resources": {
+            "memory_gb": 4,
+            "runtime": "01:00:00",
+        },
+        "args": {
+            "path": "notebooks/analysis.ipynb",
+        },
+    }
+    defaults.update(overrides)
+    return defaults


### PR DESCRIPTION
## Albrja/mic 7063/v2 notebook step

### Implementation of notebook step type
- *Category*: Implementation
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-7063

### Changes and notes
-implementation for notebook step type

### Code reviewer
PR Review: Add NotebookStepConfig to Workflow System
Summary
This PR introduces NotebookStepConfig, a new step type for the psimulate workflow system that allows users to execute Jupyter notebooks via papermill as workflow steps. The implementation follows the existing BaseStepConfig pattern with a @dataclass subclass that validates configuration, builds a papermill shell command, and supports serialization/deserialization via to_dict()/from_dict(). It includes comprehensive unit tests covering validation, command building, round-trip serialization, and YAML integration. Shared validation logic (_validate_scalar_dict) was extracted as a module-level utility reusable by both NotebookStepConfig and PythonStepConfig.

Design
Bug: Incorrect papermill -y flag usage in _build_command() — config.py:1114-1119

The code emits -y {key} {yaml_value} (e.g., -y verbose true), but papermill's -y/--parameters_yaml flag takes a single YAML string argument, not a name-value pair. With click's multiple=True, -y verbose parses "verbose" as the YAML snippet and true becomes a stray positional argument, causing a runtime error.

Fix:


yaml_snippet = f"{key}: {yaml_value}"parts.append(f"-y {shlex.quote(yaml_snippet)}")
This produces -y 'verbose: true', which papermill correctly parses as {verbose: True}.

_IDENTIFIER_RE allows hyphens, which are invalid Python identifiers — config.py:56

The shared regex ^[a-zA-Z0-9_-]+$ permits keys like my-param. Papermill injects parameters as Python variable assignments, so hyphens cause SyntaxError at notebook execution time. The regex is intentionally permissive for PythonStepConfig (where --my-param is valid), so NotebookStepConfig._validate() should add its own stricter check (e.g., ^[a-zA-Z_][a-zA-Z0-9_]*$).

Promoted dataclass fields (vs. opaque args dict) is the right choice. This is consistent with SimulationStepConfig and PytestStepConfig. PythonStepConfig's opaque self.args dict is the outlier, not NotebookStepConfig. The promoted fields provide type safety, IDE support, and clear required-vs-optional semantics.

parameters type hint could be narrowed — config.py:1083. dict[str, Any] could be dict[str, str | int | float | bool | None] to make the validated invariant visible to type checkers. Minor improvement.

Maintainability
Hardcoded kernel name "python3" with no override — config.py:1100. The class docstring states it "exposes a notebook-agnostic schema so the executor can be swapped later," but -k python3 is a magic string. Extract to a class-level constant (e.g., _DEFAULT_KERNEL: ClassVar[str] = "python3") so it's discoverable and documented as intentionally not yet configurable.

Raw KeyError when output_path is missing from YAML args — config.py:1153. _build_from_dict accesses args["output_path"] unconditionally. A user omitting output_path gets a bare KeyError with no step name or guidance, unlike every other validation path. Either guard with .get() + explicit ValueError, or validate presence before accessing.

-k python3 is a single string element — config.py:1100. Elsewhere flags and values are separate entries or individually shlex.quote-d. Use "-k", shlex.quote("python3") for consistency. This prevents a latent injection risk if the kernel becomes configurable.

DRY
PythonStepConfig._validate_scalar partially duplicates _validate_scalar_dict — Both construct the same allowed tuple and produce the same error format. Extract a shared _check_scalar(value, label, step_name, allow_none) module-level function that both _validate_scalar_dict and _validate_positional_args call. This eliminates the duplicate logic while keeping the different call sites clean.

to_dict() envelope and _build_from_dict() resource-construction are repeated across all five step types but are small enough (~5 lines each) that extracting them now would add more indirection than value. Worth noting for when a sixth step type arrives.

Tests
No test for _build_from_dict when output_path is missing — The dataclass constructor tests catch missing fields via TypeError, but _build_from_dict would raise a raw KeyError before reaching dataclass validation. Add a test documenting this behavior (and ideally fix the implementation to produce a clear ValueError).

No float parameter type tested in _build_command — The parametrized test_build_command covers str, int, bool, None, but not float. Add a case like {"threshold": 0.05} to lock in formatting.

to_dict omission of optional fields is untested — test_to_dict_serialization sets all optional fields. There's no companion test verifying that parameters, cwd, and environment are omitted when unset.

Round-trip test doesn't assert cwd or environment — test_config.py:1264-1283. A bug in cwd/environment deserialization could go undetected.

No E2E test for notebook steps — test_workflow_e2e.py tests command, python, and command steps but no notebook step. This is the highest-risk coverage gap.

No adversarial-input test for shlex.quote safety — Parameter values go through shlex.quote, but no test verifies this with values like $(rm -rf /). This is a security-relevant code path worth pinning.

make_notebook_step_dict default is incomplete — utilities.py:137-154. Missing output_path in default args means the helper can't be used bare with from_dict(), unlike sibling helpers.

Documentation
Design document is out of date — pipeline_automation_plan.md:217 describes a flat notebook schema with auto-inferred output_path ({output_directory}/executed/<name>), but the implementation requires output_path explicitly in a nested args dict. This would mislead anyone referencing the design doc to write pipeline YAML.

Class docstring and field docstrings are accurate and well-written. The YAML example correctly reflects the nested args schema, and the Notes on parameter mapping are clear.

Functionality
_build_command() produces an invalid papermill command for bool/None parameters (see Design #1). This will cause runtime failures for any notebook step that uses bool or None parameter values. The str/int/float paths work correctly since they use -p which does take NAME VALUE pairs.

Hyphened parameter keys will silently pass validation but fail at notebook execution time (see Design #2). Users would get a confusing SyntaxError from the notebook kernel rather than an upfront validation error.

_build_from_dict does not validate that path key exists in args either — config.py:1152. Both path and output_path are accessed unconditionally. A YAML missing args.path would produce a bare KeyError with no context.

cwd defaulting to self.path.parent is correct — but when path is relative (before _build_from_dict resolves it), the parent might not be meaningful. Since _build_from_dict calls Path(args["path"]).resolve() before constructing the dataclass, this is fine in practice. The direct-construction case (without from_dict) could theoretically pass a relative path with no cwd override, making the cwd effectively relative too — but this seems like an acceptable edge case.

Minor Nits
config.py:1089 — The _validate method's f-string f"got {self.path!r}." uses an f-string concatenation (f"..." f"...") that could be a single f-string for readability.
Overall
The overall design is sound and consistent with the existing step type family. The most critical issue is the incorrect papermill -y flag usage (Design #1), which is a runtime correctness bug affecting any notebook step with boolean or None parameters. The hyphen-in-parameter-keys issue (Design #2) is a latent runtime error. The missing output_path validation (Maintainability #2) produces a poor user experience. The remaining findings are test coverage gaps and documentation staleness. After fixing the -y flag bug and adding paramet
