### PR TITLE
Support specifying archive node on cluster

### DIFF
--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -25,6 +25,8 @@ class NativeSpecification(NamedTuple):
     hardware: list[str]
     cores: int = 1
     """Number of CPU cores to request from SLURM. Default is 1."""
+    requires_archive_node: bool = False
+    """Whether the task must land on a node tagged with the SLURM ``archive`` feature."""
 
     def to_jobmon_spec(self, worker_logging_root: Path) -> dict[str, Any]:
         """Build the Jobmon compute resources dict from this NativeSpecification.
@@ -42,8 +44,16 @@ class NativeSpecification(NamedTuple):
         -----
         * ``memory`` is passed in **GB** because the Jobmon SLURM plugin performs
           its own GB → MB conversion internally.
-        * ``constraints`` is a pipe-separated string of SLURM feature names
-          (e.g. ``"r650|r650v2"``), included only when hardware is requested.
+        * ``constraints`` is a SLURM ``--constraint`` expression built from
+          ``hardware`` and ``requires_archive_node``:
+
+          - hardware only: pipe-joined (OR), e.g. ``"r650|r650v2"``.
+          - archive only: ``"archive"``.
+          - both: AND-joined, e.g. ``"r650&archive"`` or
+            ``"(r650|r650v2)&archive"`` (the hardware group is
+            parenthesized when it has more than one entry).
+          - neither: the key is omitted.
+
         * ``standard_output`` and ``standard_error`` route SLURM stdout/stderr
           to the cluster logs directory. The Jobmon SLURM plugin appends the
           task name and SLURM job ID to these paths automatically.
@@ -57,9 +67,24 @@ class NativeSpecification(NamedTuple):
             "stdout": str(worker_logging_root),
             "stderr": str(worker_logging_root),
         }
-        if self.hardware:
-            resources["constraints"] = "|".join(self.hardware)
+        constraint = self._build_constraint()
+        if constraint is not None:
+            resources["constraints"] = constraint
         return resources
+
+    def _build_constraint(self) -> str | None:
+        """Build the SLURM ``--constraint`` expression, or ``None`` if unconstrained."""
+        parts: list[str] = []
+        if self.hardware:
+            hw = "|".join(self.hardware)
+            if len(self.hardware) > 1 and self.requires_archive_node:
+                hw = f"({hw})"
+            parts.append(hw)
+        if self.requires_archive_node:
+            parts.append("archive")
+        if not parts:
+            return None
+        return "&".join(parts)
 
     @staticmethod
     def _runtime_to_seconds(runtime_str: str) -> int:

--- a/src/vivarium_cluster_tools/psimulate/cluster/interface.py
+++ b/src/vivarium_cluster_tools/psimulate/cluster/interface.py
@@ -45,14 +45,11 @@ class NativeSpecification(NamedTuple):
         * ``memory`` is passed in **GB** because the Jobmon SLURM plugin performs
           its own GB → MB conversion internally.
         * ``constraints`` is a SLURM ``--constraint`` expression built from
-          ``hardware`` and ``requires_archive_node``:
-
-          - hardware only: pipe-joined (OR), e.g. ``"r650|r650v2"``.
-          - archive only: ``"archive"``.
-          - both: AND-joined, e.g. ``"r650&archive"`` or
-            ``"(r650|r650v2)&archive"`` (the hardware group is
-            parenthesized when it has more than one entry).
-          - neither: the key is omitted.
+          ``hardware`` and ``requires_archive_node``. The hardware group is
+          always parenthesized and pipe-joined (OR); ``archive`` is AND-joined
+          when required. Examples: ``"(r650)"``, ``"(r650|r650v2)"``,
+          ``"(r650)&archive"``, ``"(r650|r650v2)&archive"``, ``"archive"``.
+          The key is omitted when neither is set.
 
         * ``standard_output`` and ``standard_error`` route SLURM stdout/stderr
           to the cluster logs directory. The Jobmon SLURM plugin appends the
@@ -76,10 +73,7 @@ class NativeSpecification(NamedTuple):
         """Build the SLURM ``--constraint`` expression, or ``None`` if unconstrained."""
         parts: list[str] = []
         if self.hardware:
-            hw = "|".join(self.hardware)
-            if len(self.hardware) > 1 and self.requires_archive_node:
-                hw = f"({hw})"
-            parts.append(hw)
+            parts.append(f"({'|'.join(self.hardware)})")
         if self.requires_archive_node:
             parts.append("archive")
         if not parts:

--- a/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
+++ b/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
@@ -142,6 +142,13 @@ class ResourceConfig:
     """Number of CPU cores to request. Default is 1."""
     hardware: list[str] | None = None
     """Optional list of hardware types to target (e.g. ``["r650", "r650v2"]``)."""
+    requires_archive_node: bool = False
+    """Whether the step requires landing on an archive node.
+
+    When ``False`` (default), tasks may land on any node — archive or
+    non-archive. When ``True``, tasks are constrained to archive nodes
+    only (those tagged with the SLURM ``archive`` feature).
+    """
 
     _RUNTIME_RE = re.compile(r"^\d{2}:\d{2}:\d{2}$")
 
@@ -190,6 +197,8 @@ class ResourceConfig:
             kwargs["cores"] = data["cores"]
         if "hardware" in data:
             kwargs["hardware"] = data["hardware"]
+        if "requires_archive_node" in data:
+            kwargs["requires_archive_node"] = data["requires_archive_node"]
         return cls(**kwargs)
 
     def to_dict(self) -> dict[str, Any]:
@@ -206,6 +215,8 @@ class ResourceConfig:
             result["cores"] = self.cores
         if self.hardware is not None:
             result["hardware"] = self.hardware
+        if self.requires_archive_node:
+            result["requires_archive_node"] = True
         return result
 
     def to_native_specification(self, job_name: str) -> NativeSpecification:
@@ -229,6 +240,7 @@ class ResourceConfig:
             max_runtime=self.runtime,
             hardware=self.hardware or [],
             cores=self.cores,
+            requires_archive_node=self.requires_archive_node,
         )
 
 

--- a/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
+++ b/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
@@ -143,12 +143,7 @@ class ResourceConfig:
     hardware: list[str] | None = None
     """Optional list of hardware types to target (e.g. ``["r650", "r650v2"]``)."""
     requires_archive_node: bool = False
-    """Whether the step requires landing on an archive node.
-
-    When ``False`` (default), tasks may land on any node — archive or
-    non-archive. When ``True``, tasks are constrained to archive nodes
-    only (those tagged with the SLURM ``archive`` feature).
-    """
+    """Whether to enforce landing on an archive node."""
 
     _RUNTIME_RE = re.compile(r"^\d{2}:\d{2}:\d{2}$")
 

--- a/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
+++ b/src/vivarium_cluster_tools/psimulate/workflow_config/config.py
@@ -165,6 +165,12 @@ class ResourceConfig:
                 validate_runtime_and_queue(self.runtime, self.queue)
         if self.hardware is not None:
             validate_hardware(self.hardware)
+        if not isinstance(self.requires_archive_node, bool):
+            raise TypeError(
+                f"'requires_archive_node' must be a bool, "
+                f"got {type(self.requires_archive_node).__name__}: "
+                f"{self.requires_archive_node!r}."
+            )
 
     @classmethod
     def from_dict(

--- a/tests/psimulate/cluster/test_interface.py
+++ b/tests/psimulate/cluster/test_interface.py
@@ -84,22 +84,36 @@ class TestNativeSpecification:
         assert spec["stderr"] == str(worker_logging_root)
 
     @pytest.mark.parametrize(
-        "hardware, expected_constraints",
+        "hardware, requires_archive_node, expected_constraints",
         [
-            (["r650"], "r650"),
-            (["r650", "r650v2"], "r650|r650v2"),
-            (["a100", "h100", "l40s"], "a100|h100|l40s"),
-            ([], None),
+            (["r650"], False, "r650"),
+            (["r650", "r650v2"], False, "r650|r650v2"),
+            (["a100", "h100", "l40s"], False, "a100|h100|l40s"),
+            ([], False, None),
+            ([], True, "archive"),
+            (["r650"], True, "r650&archive"),
+            (["r650", "r650v2"], True, "(r650|r650v2)&archive"),
+            (["a100", "h100", "l40s"], True, "(a100|h100|l40s)&archive"),
         ],
-        ids=["single", "two", "three", "empty"],
+        ids=[
+            "hw-single",
+            "hw-two",
+            "hw-three",
+            "none",
+            "archive-only",
+            "hw-single-archive",
+            "hw-two-archive",
+            "hw-three-archive",
+        ],
     )
     def test_to_jobmon_spec_hardware_constraints(
         self,
         worker_logging_root: Path,
         hardware: list[str],
+        requires_archive_node: bool,
         expected_constraints: str | None,
     ) -> None:
-        """Hardware list is pipe-joined into 'constraints'; empty list omits the key."""
+        """Constraint string combines ``hardware`` (OR) with archive (AND)."""
         ns = NativeSpecification(
             job_name="j",
             project="p",
@@ -107,6 +121,7 @@ class TestNativeSpecification:
             peak_memory=2.0,
             max_runtime="00:30:00",
             hardware=hardware,
+            requires_archive_node=requires_archive_node,
         )
         spec = ns.to_jobmon_spec(worker_logging_root)
         if expected_constraints is None:

--- a/tests/psimulate/cluster/test_interface.py
+++ b/tests/psimulate/cluster/test_interface.py
@@ -86,12 +86,12 @@ class TestNativeSpecification:
     @pytest.mark.parametrize(
         "hardware, requires_archive_node, expected_constraints",
         [
-            (["r650"], False, "r650"),
-            (["r650", "r650v2"], False, "r650|r650v2"),
-            (["a100", "h100", "l40s"], False, "a100|h100|l40s"),
+            (["r650"], False, "(r650)"),
+            (["r650", "r650v2"], False, "(r650|r650v2)"),
+            (["a100", "h100", "l40s"], False, "(a100|h100|l40s)"),
             ([], False, None),
             ([], True, "archive"),
-            (["r650"], True, "r650&archive"),
+            (["r650"], True, "(r650)&archive"),
             (["r650", "r650v2"], True, "(r650|r650v2)&archive"),
             (["a100", "h100", "l40s"], True, "(a100|h100|l40s)&archive"),
         ],

--- a/tests/psimulate/workflow_config/test_config.py
+++ b/tests/psimulate/workflow_config/test_config.py
@@ -238,6 +238,38 @@ class TestResourceConfigValidation:
         assert rc.runtime == "02:00:00"
         assert rc.cores == 4
 
+    def test_requires_archive_node_defaults_false(self) -> None:
+        rc = ResourceConfig(memory_gb=1)
+        assert rc.requires_archive_node is False
+
+    def test_from_dict_reads_requires_archive_node(self) -> None:
+        rc = ResourceConfig.from_dict({"memory_gb": 4, "requires_archive_node": True})
+        assert rc.requires_archive_node is True
+
+    def test_to_dict_emits_requires_archive_node_only_when_true(self) -> None:
+        rc_default = ResourceConfig(memory_gb=4, project="proj_simscience", queue="all.q")
+        assert "requires_archive_node" not in rc_default.to_dict()
+
+        rc_archive = ResourceConfig(
+            memory_gb=4,
+            project="proj_simscience",
+            queue="all.q",
+            requires_archive_node=True,
+        )
+        assert rc_archive.to_dict()["requires_archive_node"] is True
+
+    def test_to_native_specification_passes_archive_flag(self) -> None:
+        rc = ResourceConfig(
+            memory_gb=4,
+            project="proj_simscience",
+            queue="all.q",
+            hardware=["r650"],
+            requires_archive_node=True,
+        )
+        native = rc.to_native_specification(job_name="job")
+        assert native.requires_archive_node is True
+        assert native.hardware == ["r650"]
+
 
 class TestBaseStepConfig:
     """Tests for behavior implemented in BaseStepConfig (tested via concrete subclasses)."""


### PR DESCRIPTION
## Support specifying archive node on cluster

### Implement feature to specify whether a Jobmon task requires a archive cluster node
- *Category*: Feature
- *JIRA issue*: https://jira.ihme.washington.edu/browse/MIC-6962

### Changes and notes
-support configuration for required archive node on slurm cluster
-the purpose of this is to be able to read data stored in certain places on the filesystem that non-archive nodes do not have access to

### Code reviwer
PR Review: Add requires_archive_node resource option for SLURM archive node constraint
Summary
This PR introduces a requires_archive_node: bool field to NativeSpecification (the low-level SLURM specification) and ResourceConfig (the YAML-facing workflow configuration). When set to True, tasks are constrained to SLURM nodes tagged with the archive feature. The implementation correctly builds SLURM --constraint expressions that AND-join the archive requirement with any hardware OR-group (parenthesizing appropriately for operator precedence). The feature is exposed only through workflow YAML configuration — the psimulate run/restart/expand CLI commands continue to use the False default.

Design
Boolean is the correct representation. "archive" is a SLURM feature tag, semantically distinct from hardware model names. Keeping it separate from hardware: list[str] avoids conflating two SLURM concepts and doesn't break validate_hardware(). No change needed.

Constraint algebra is correct. SLURM's & binds tighter than |, so r650|r650v2&archive would parse incorrectly. The interface.py:77 method correctly parenthesizes the hardware OR-group only when multiple hardware entries are combined with archive. The test matrix covers all quadrants.

Missing type validation on requires_archive_node from YAML input. At config.py:200-201, the value from data["requires_archive_node"] is passed through without type checking. If a user writes requires_archive_node: "true" (quoted string in YAML), it becomes a truthy string that behaves like True in boolean contexts but isn't actually a bool. Other fields (project, runtime, hardware) are validated in __post_init__, but this one is not. A string like "no" would be truthy and silently produce the wrong behavior.

Suggestion: Add to __post_init__:


if not isinstance(self.requires_archive_node, bool):    raise TypeError(        f"'requires_archive_node' must be a bool, "        f"got {type(self.requires_archive_node).__name__}: "        f"{self.requires_archive_node!r}."    )
Maintainability
Magic string "archive" in interface.py:84. The SLURM feature tag appears as a bare string literal. Extracting to a module-level constant (e.g., _SLURM_ARCHIVE_FEATURE = "archive") would improve discoverability and guard against typos.

Docstring placement on NamedTuple fields. The trailing docstrings for cores and requires_archive_node are not attached as __doc__ attributes at runtime (unlike dataclass fields). This is consistent with the existing pattern in the file, so no action needed, but worth noting if future Sphinx output seems incomplete.

DRY
Pre-existing: Four near-identical NativeSpecification(...) constructions in cli.py:170. The run, restart, expand, and load_test commands each construct the spec with the same 6 keyword arguments differing only in job_name. If requires_archive_node ever needs CLI exposure, all 4 must be updated. Extracting a helper would eliminate this risk. This is pre-existing, not introduced by the PR.
Tests
Missing round-trip test (from_dict → to_dict). The two directions are tested independently but not together. A round-trip test for both True and False values would catch regressions where one direction silently drops or flips the flag.

Missing YAML integration test. No test exercises requires_archive_node flowing through the full WorkflowConfig.from_yaml_with_cli_overrides pipeline. A test using make_step_dict(resources={"memory_gb": 4, "requires_archive_node": True}) through write_workflow_yaml → from_yaml_with_cli_overrides would verify YAML parsing preserves the value.

to_native_specification only tested for True; no assertion that False propagates. If the method accidentally hardcoded True, existing tests wouldn't catch it. Adding a one-line assertion for the default case is cheap insurance.

Documentation
CHANGELOG not updated. The 3.2.0 entry in CHANGELOG.rst:3 doesn't mention requires_archive_node. This is a user-facing configuration addition.

Suggestion: Add:


- Add ``requires_archive_node`` resource option for constraining workflow steps to SLURM archive nodes
ResourceConfig.requires_archive_node docstring doesn't explain interaction with hardware. Since this is the user-facing class, users writing YAML should understand that both fields combine into a single --constraint expression (e.g., (r650|r650v2)&archive) rather than being separate SLURM flags.

Suggestion: Append to the docstring at config.py:146:


When combined with ``hardware``, the archive requirement is AND-joinedwith the hardware constraint, e.g. ``(r650|r650v2)&archive``.
No user-facing documentation for the workflow YAML schema. The docs have no page describing the psimulate workflow command or its YAML format. The requires_archive_node option (and indeed the entire workflow feature) is undiscoverable without reading source. This is a broader gap that pre-dates this PR.

Functionality
to_dict() serialization is asymmetric but correct. When requires_archive_node is False, to_dict() omits the key entirely. When from_dict() receives a dict without the key, it defaults to False. This round-trips correctly. No issue here.

CLI callers are safe. All four NativeSpecification(...) calls in cli.py omit requires_archive_node, relying on the False default. Since the NamedTuple default is False, this is correct — CLI users don't get archive-pinned unintentionally.

No edge case issue with hardware=[] + requires_archive_node=True. _build_constraint() handles this by skipping the hardware branch (empty list is falsy) and only appending "archive". The test at id "archive-only" covers this case.

Minor Nits
The _build_constraint docstring at interface.py:77 could note it returns None when neither hardware nor archive is specified, to match the public to_jobmon_spec notes about "neither: the key is omitted."
Overall
This is a clean, well-scoped PR with correct SLURM constraint algebra and good test coverage. The three actionable items are:

Priority	Item
Medium	Add isinstance(self.requires_archive_node, bool) type validation in ResourceConfig.__post_init__
Low	Add CHANGELOG entry
Low	Document the hardware + requires_archive_node interaction in the ResourceConfig docstring
